### PR TITLE
add pychromVAR

### DIFF
--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -1,0 +1,17 @@
+name: pychromVAR
+description: |
+    A python pacakge for chromVAR.
+project_home: https://github.com/lzj1769/pychromVAR
+documentation_home: https://pychromvar.readthedocs.io/en/latest/
+tutorials_home: https://pychromvar.readthedocs.io/en/latest/
+install:
+    pypi: pychromvar
+tags:
+    - TF
+    - scATAC-seq
+license: MIT License (MIT)
+version: v0.0.3
+authors:
+    - Zhijian Li
+test_command: |
+    test_command: pip install ".[test]" && pytest

--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -9,7 +9,7 @@ install:
 tags:
     - TF
     - scATAC-seq
-license: MIT License (MIT)
+license: MIT
 version: v0.0.3
 authors:
     - Zhijian Li


### PR DESCRIPTION
Name of the tool: pychromVAR

Short description: A python package for chromVAR

How does the package use scverse data structures (please describe in a few sentences): 
The package uses Anndata and Mudata for estimating motifs binding sites accessibility deviations from scATAC-seq.

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
-   [x] The package provides versioned releases
-   [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
-   [x] The package uses automated software tests and runs them via continuous integration (CI)
-   [x] The package provides API documentation via a website or README
-   [x] The package uses scverse datastructures where appropriate (i.e.anndata/mudata and their modality-specific extensions)
-   [x] I am the author or maintainer of the tool and agree on listing the package on the scverse website
