### PR TITLE
Add PyDESeq2

### DIFF
--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -1,0 +1,23 @@
+name: PyDESeq2
+description: |
+    PyDESeq2 is a python package for bulk RNA-seq differential expression analysis. It is a re-implementation
+    from scratch of the main features of the R package DESeq2 (Love et al. 2014).
+project_home: https://github.com/owkin/PyDESeq2
+documentation_home: https://pydeseq2.readthedocs.io
+tutorials_home: https://pydeseq2.readthedocs.io/en/latest/auto_examples/index.html
+install:
+    pypi: pydeseq2
+license: MIT
+tags:
+    - rna-seq
+    - differential-expression
+publications:
+    - 10.1101/2022.12.14.520412
+version: v0.3.0
+authors:
+    - BorisMuzellec
+    - maikia
+    - vcabeli
+    - mandreux-owkin
+test_command: |
+    pip install ."[dev]" && pytest


### PR DESCRIPTION
*Name of the tool:* PyDESeq2

*Short description:* PyDESeq2 is a python package for bulk RNA-seq differential expression analysis. It is a re-implementation from scratch of the main features of the R package DESeq2 (Love et al. 2014).

*How does the package use scverse data structures (please describe in a few sentences):* PyDESeq2 does its heavy lifting using the `DeseqDataSet` class, which extends `AnnData`. In particular, read counts are stored in the `X` attribute, clinical metadata in `obs` and learned parameters in the relevant `varm` or `obsm` fields.

### Checklist

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
-   [x] The package provides versioned releases
-   [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
-   [x] The package uses automated software tests and runs them via continuous integration (CI)
-   [x] The package provides API documentation via a website or README
-   [x] The package uses scverse datastructures where appropriate (i.e.anndata/mudata and their modality-specific extensions)
-   [x] I am the author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

-   [x] The package provides tutorials (or "vignettes") that help getting users started quickly
-   [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).

Closes owkin/PyDESeq2#15.