### PR TITLE
add symphonypy package

### DIFF
--- a/packages/symphonypy/meta.yaml
+++ b/packages/symphonypy/meta.yaml
@@ -1,0 +1,17 @@
+name: Symphonypy
+description: |
+  Symphonypy is a pure Python port of Symphony label transfer algorithm for reference-based cell type
+  annotation.
+project_home: https://github.com/potulabe/symphonypy
+documentation_home: https://github.com/potulabe/symphonypy
+install:
+  pypi: symphonypy
+tags:
+  - label-transfer
+license: GPL-3.0-only
+version: v0.2.1
+authors:
+  - serjisa
+  - potulabe
+test_command: |
+  pip install . && pytest


### PR DESCRIPTION
Name of the tool: symphonypy

Short description: Python port of Symphony label transfer algorithm for reference-based cell type annotation.

How does the package use scverse data structures (please describe in a few sentences): it's fully integrated in standard scanpy-based single-cell RNA-Seq processing pipeline and uses AnnData containers for all of the data manipulations.

+ The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
+ The package provides versioned releases
+ The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
+ The package uses automated software tests and runs them via continuous integration (CI)
+ The package provides API documentation via a website or README
+ The package uses scverse datastructures where appropriate (i.e.anndata/mudata and their modality-specific extensions)
+ I am the author or maintainer of the tool and agree on listing the package on the scverse website

+ I would like this package to be announced on scverse channels (zulip, discourse, twitter): twitter @sv_isaev
+ The package provides tutorials (or "vignettes") that help getting users started quickly