### PR TITLE
adding scyan meta.yml file

### DIFF
--- a/packages/scyan/meta.yaml
+++ b/packages/scyan/meta.yaml
@@ -1,0 +1,22 @@
+name: scyan
+description: |
+  Biology-driven deep generative model for cell-type annotation in cytometry.
+  Scyan is an interpretable model that also corrects batch-effect and
+  can be used for debarcoding or population discovery.
+project_home: https://github.com/MICS-Lab/scyan
+documentation_home: https://mics-lab.github.io/scyan/
+tutorials_home: https://mics-lab.github.io/scyan/tutorials/usage/
+publications:
+  - 10.1093/bib/bbad260
+install:
+  pypi: scyan
+tags:
+  - cytometry
+  - annotation
+  - batch-effect correction
+  - debarcoding
+license: BSD-3-Clause
+version: v1.5.0
+authors:
+  - quentinblampey
+test_command: pip install ".[dev]" && pytest


### PR DESCRIPTION
Name of the tool: `scyan`

Short description: Scyan is a biology-driven deep generative model (more precisely, a normalizing flow) for cell-type annotation in **cytometry**. It is an interpretable model that also corrects batch-effect and can be used for debarcoding or population discovery.

How does the package use scverse data structures (please describe in a few sentences): it is entirely based on `anndata` (for users that are not used to `anndata`, we have `.FCS` readers that makes `anndata` objects). The package design is also similar to `scanpy` (e.g., `scyan.plot` or `scyan.tools`). NB: as `scanpy` is not meant for cytometry, it is not a dependency of `scyan`, but we re-use only one function of scanpy (we mentioned in a README and in a comment that it was copied from scanpy).

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
-   [x] The package provides versioned releases
-   [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
-   [x] The package uses automated software tests and runs them via continuous integration (CI)
-   [x] The package provides API documentation via a website or README
-   [x] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
-   [x] I am the author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

-   [x] I would like this package to be announced on scverse channels (zulip, discourse, twitter) [Include twitter handles you want us to tag]
-   [x] The package provides tutorials (or "vignettes") that help getting users started quickly
-   [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).