### PR TITLE
gssnng

### DIFF
--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -20,4 +20,4 @@ authors:
   - gibbsdavidl
   - redst4r
 test_command: |
- git clone git@github.com:IlyaLab/gssnng.git && pip install gssnng && pip install pytest && cd gssnng/ && pytest 
+  git clone git@github.com:IlyaLab/gssnng.git && pip install gssnng && pip install pytest && cd gssnng/ && pytest

--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -1,0 +1,23 @@
+name: gssnng
+description: |
+  Single-cell gene set scoring with nearest neighbor graph smoothed data.
+project_home: https://github.com/IlyaLab/gssnng
+documentation_home: https://gssnng.readthedocs.io/en/latest/
+tutorials_home: https://github.com/IlyaLab/gssnng/tree/main/notebooks
+publications:
+  - 10.1093/bioadv/vbad150
+install:
+  pypi: gssnng
+tags:
+  - scRNA-seq
+  - GSEA
+  - geneset-scoring
+  - smoothing
+  - python
+license: MIT
+version: v0.4.2
+authors:
+  - gibbsdavidl
+  - redst4r
+test_command: |
+ git clone git@github.com:IlyaLab/gssnng.git && pip install gssnng && pip install pytest && cd gssnng/ && pytest 


### PR DESCRIPTION
Mandatory
Name of the tool: gssnng

Short description: This tool uses the nearest neighbor graph of cells --within question driven groups-- for matrix smoothing to produce high quality gene set scores on a per-cell, per-group, level which is useful for visualization and statistical analysis.

How does the package use scverse data structures (please describe in a few sentences): Adds the gene set scores into the AnnData obs table for plotting with scanpy.pl functions.

 The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license  [Yes]
 The package provides versioned releases [Yes]
 The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda) [Yes]
 The package uses automated software tests and runs them via continuous integration (CI)  [Yes]
 The package provides API documentation via a website or README  [Yes]
 The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions) [Yes]
 I am an author or maintainer of the tool and agree on listing the package on the scverse website [Yes]
Recommended
 Please announce this package on scverse communication channels (zulip, discourse, twitter) ok
 Please tag the author(s) these announcements. Handles (e.g. @scverse_team) to include are:
Twitter: @gibbsdavidl
Zulip:
Discourse:
Mastodon:
 The package provides tutorials (or "vignettes") that help getting users started quickly [Yes]
 The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse). [No]