### PR TITLE
InSTAnT

### DIFF
--- a/packages/InSTAnT/meta.yaml
+++ b/packages/InSTAnT/meta.yaml
@@ -1,0 +1,17 @@
+name: InSTAnT
+description: |
+  InSTAnT is a toolkit to identify gene pairs which are d-colocalized from single molecule measurement data e.g. MERFISH or SeqFISH.
+  A gene pair is d-colocalized when their transcripts are within distance d across many cells.
+project_home: https://github.com/bhavaygg/InSTAnT
+documentation_home: https://github.com/bhavaygg/InSTAnT
+publications:
+  - 10.21203/rs.3.rs-2481749/v1
+install:
+  pypi: sc-instant
+license: MIT
+version: 1.1.1
+authors:
+  - bhavaygg
+  - anurendra
+test_command: |
+  pip install sc-instant


### PR DESCRIPTION
Mandatory
Name of the tool: InSTAnT

Short description: InSTAnT is a toolkit to identify gene pairs which are d-colocalized from single molecule measurement data e.g. MERFISH or SeqFISH. A gene pair is d-colocalized when their transcripts are within distance d across many cells.

How does the package use scverse data structures (please describe in a few sentences): The package offers support for `anndata` input/output.

- [x]  The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
- [x]  The package provides versioned releases
- [x]  The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
- [x]  The package uses automated software tests and runs them via continuous integration (CI)
- [x]  The package provides API documentation via a website or README
- [x]  The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
- [x]  I am an author or maintainer of the tool and agree on listing the package on the scverse website