### PR TITLE
Add palantir to the scverse

### DIFF
--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -1,0 +1,31 @@
+name: Palantir
+description: |
+  Palantir is an algorithm to align cells along differentiation trajectories.
+  Palantir models differentiation as a stochastic process where stem cells
+  differentiate to terminally differentiated cells by a series of steps through
+  a low dimensional phenotypic manifold. Palantir effectively captures the
+  continuity in cell states and the stochasticity in cell fate determination.
+  Palantir has been designed to work with multidimensional single cell data from
+  diverse technologies such as Mass cytometry and single cell RNA-seq.
+project_home: https://github.com/dpeerlab/Palantir
+documentation_home: https://palantir.readthedocs.io
+publications:
+  - 10.1038/s41587-019-0068-4
+install:
+  pypi: palantir
+tags:
+  - markov-chain
+  - dimensionality-reduction
+  - scrna-seq
+  - trajectory-generation
+  - diffusion-maps
+  - differentiation
+  - manifold-learning
+  - single-cell-genomics
+  - cell-fate-transitions
+  - scrna-seq-analysis
+license: GPL-2.0-or-later
+version: v1.3.3
+authors:
+  - ManuSetty
+test_command: pip install -e '.' && pip install flake8 pytest coverage typing-extensions && pytest

--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -28,4 +28,6 @@ license: GPL-2.0-or-later
 version: v1.3.3
 authors:
   - ManuSetty
+  - dpeerlab
+  - katosh
 test_command: pip install -e '.' && pip install flake8 pytest coverage typing-extensions && pytest


### PR DESCRIPTION
This PR is a submission of [palantir](https://github.com/dpeerlab/Palantir) to the scverse. Palantir is already part of `scanpy.external.tl`. However, since `scanpy.external` seems to be deprecated, and palantir is still being maintained, we would like to make this addition to the scversen to remain part of the ecosystem.


### Mandatory

Name of the tool: palantir

Short description: Palantir is an algorithm to align cells along differentiation trajectories. Palantir models differentiation as a stochastic process where stem cells differentiate to terminally differentiated cells by a series of steps through a low dimensional phenotypic manifold. Palantir effectively captures the continuity in cell states and the stochasticity in cell fate determination. Palantir has been designed to work with multidimensional single cell data from diverse technologies such as Mass cytometry and single cell RNA-seq.

How does the package use scverse data structures (please describe in a few sentences): All functions of the main processing pipeline accept anndata objects as input and write all their output into the passed anndata for further processing. Many functions take arguments that specify the .obsm or .layer to use for input and output of the respective processing step.

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
-   [x] The package provides versioned releases
-   [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
-   [x] The package uses automated software tests and runs them via continuous integration (CI)
-   [x] The package provides API documentation via a website or README
-   [x] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
-   [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

-   [ ] Please announce this package on scverse communication channels (zulip, discourse, twitter)
-   [ ] Please tag the author(s) these announcements. Handles (e.g. `@scverse_team`) to include are:
    -   Twitter:
    -   Zulip:
    -   Discourse:
    -   Mastodon:
-   [x] The package provides tutorials (or "vignettes") that help getting users started quickly
-   [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).

@ManuSetty