### PR TITLE
Add pytximport

### DIFF
--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -1,0 +1,20 @@
+name: pytximport
+description: |
+  A Python port of the `tximport` R package for importing transcript-level quantification data from various RNA-seq quantification tools such as `salmon` and `kallisto` and summarizing it to the gene level.
+project_home: https://github.com/complextissue/pytximport
+documentation_home: https://pytximport.readthedocs.io/en/latest/
+tutorials_home: https://pytximport.readthedocs.io/en/latest/
+install:
+  pypi: pytximport
+tags:
+  - rna-seq
+  - bulk-rna-seq
+  - differential-expression
+license: GPL-3.0-only
+version: v0.2.0
+authors:
+  - maltekuehl
+test_command: |
+  pip install flit poetry && \
+	flit install --deps all && \
+  coverage run -m pytest

--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -16,5 +16,5 @@ authors:
   - maltekuehl
 test_command: |
   pip install flit poetry && \
-	flit install --deps all && \
+  flit install --deps all && \
   coverage run -m pytest


### PR DESCRIPTION
Name of the tool: pytximport

Short description: `pytximport` is a Python port of the popular `tximport` Bioconductor package (unaffiliated with the `tximport` authors) and allows users to convert transcription level quantification files from pseudoalignment/quasi-mapping tools like `kallisto` and `salmon` to gene-level count estimates, thereby enabling the use of downstream gene differential expression analysis tools such as `PyDESeq2`. Depending on its configuration, `pytximport` corrects for differential transcript usage between samples, provides a length offset matrix for downstream correction, filters by transcript biotype or even returns corrected transcript-level data for differential transcript expression analysis.

How does the package use scverse data structures (please describe in a few sentences): AnnData objects are an available return type and the CLI version can save results as .h5ad files. The AnnData objects can be used for downstream analysis with `PyDESeq2` and other tools and the vignette describes how to do so.

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license: GPL v3
-   [X] The package provides versioned releases: Yes, releases are tagged in GitHub and uploaded to PyPi via GitHub actions
-   [X] The package can be installed from a standard registry: PyPi
-   [X] The package uses automated software tests and runs them via continuous integration (CI): Yes, via GitHub actions
-   [X] The package provides API documentation via a website or README: Available at https://pytximport.readthedocs.io/en/latest/ and generated with Sphinx AutoAPI
-   [X] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions): AnnData objects are an available return type and the CLI version can save results as .h5ad files. 
-   [X] I am an author or maintainer of the tool and agree on listing the package on the scverse website: Yes
-   [X] Please announce this package on scverse communication channels (zulip, discourse, twitter): Yes
-   [X] Please tag the author(s) these announcements. Handles (e.g. `@scverse_team`) to include are:
    -   Twitter: @spatiomics @PuellesVictor
-   [X] The package provides tutorials (or "vignettes") that help getting users started quickly: Yes, available at https://pytximport.readthedocs.io/en/latest/example.html