### PR TITLE
Add celltypist

### DIFF
--- a/packages/celltypist/meta.yaml
+++ b/packages/celltypist/meta.yaml
@@ -1,0 +1,27 @@
+name: celltypist
+description: |
+  CellTypist is an automated cell type annotation tool for scRNA-seq datasets
+  on the basis of logistic regression classifiers optimised by the stochastic
+  gradient descent algorithm. CellTypist allows for cell prediction using
+  either built-in (with a current focus on immune sub-populations) or custom
+  models, in order to assist in the accurate classification of different cell
+  types and subtypes.
+project_home: https://github.com/Teichlab/celltypist
+documentation_home: https://celltypist.readthedocs.io
+install:
+  pypi: celltypist
+tags:
+  - python
+  - machine-learning
+  - scrna-seq
+  - single-cell
+  - cell-type-classification
+  - label-transfer
+publications:
+  - 10.1126/science.abl5197
+license: MIT
+version: v1.6.3
+authors:
+  - ChuanXu1
+  - prete
+test_command: null


### PR DESCRIPTION
### Mandatory

Name of the tool: celltypist

Short description: CellTypist is an automated cell type annotation tool for scRNA-seq datasets.

How does the package use scverse data structures (please describe in a few sentences): CellTypist uses anndata for most analyses and is dependent on Scanpy.

-   [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
-   [x] The package provides versioned releases
-   [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
-   [ ] The package uses automated software tests and runs them via continuous integration (CI)
-   [x] The package provides API documentation via a website or README
-   [x] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
-   [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

-   [ ] Please announce this package on scverse communication channels (zulip, discourse, twitter)
-   [ ] Please tag the author(s) these announcements. Handles (e.g. `@scverse_team`) to include are:
    -   Twitter:
    -   Zulip:
    -   Discourse:
    -   Mastodon:
-   [x] The package provides tutorials (or "vignettes") that help getting users started quickly
-   [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).

