### PR TITLE
Add pyUCell

### DIFF
--- a/packages/pyUCell/meta.yaml
+++ b/packages/pyUCell/meta.yaml
@@ -1,0 +1,25 @@
+name: pyUCell
+description: |
+  pyUCell is a package for evaluating gene signatures in single-cell datasets.
+  pyUCell signature scores, based on the Mann-Whitney U statistic, are robust
+  to dataset size and heterogeneity, and their calculation demands less
+  computing time and memory than other available methods, enabling the
+  processing of large datasets in a few minutes even on machines with limited
+  computing power.
+project_home: https://github.com/carmonalab/pyucell
+documentation_home: https://pyucell.readthedocs.io/en/latest
+tutorials_home: https://pyucell.readthedocs.io/en/latest/notebooks/basic.html
+publications:
+  - 10.1016/j.csbj.2021.06.043
+install:
+  pypi: pyucell
+tags:
+  - single-cell
+  - signature scoring
+  - module scoring
+license: MIT
+version: v0.3.0
+authors:
+  - mass-a
+  - sjcarmona
+test_command: pip install "." && pytest


### PR DESCRIPTION
Name of the tool: pyUCell

Short description: pyUCell is a computational method for robust and scalable single-cell signature scoring. UCell signature scores, based on the Mann-Whitney U statistic, are robust to dataset size and heterogeneity, and their calculation is very fast and memory-efficient.

How does the package use scverse data structures (please describe in a few sentences): pyUCell relies on AnnData data structures and depends on scanpy. It can be integrated in existing scanpy pipelines and offers an alternative to `scanpy.tl.score_genes()`

- [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
- [x] The package provides versioned releases
- [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
- [x] Automated tests cover essential functions of the package and a reasonable range of inputs and conditions [^1]
- [x] Continuous integration (CI) automatically executes these tests on each push or pull request [^2]
- [x] The package provides API documentation via a website or README[^3]
- [x] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
- [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

- [x] Please announce this package on scverse communication channels (zulip, discourse, twitter)
- [x] Please tag the author(s) these announcements. Handles (e.g. `@scverse_team`) to include are:
    - Zulip:
    - Discourse:
    - Mastodon:
    - Bluesky: @carmonation.bsky.social
    - Twitter: @carmonation

- [x] The package provides tutorials (or "vignettes") that help getting users started quickly
- [x] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).
