### PR TITLE
Add AESTETIK to the ecosystem

### DIFF
--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -1,0 +1,29 @@
+name: AESTETIK
+description: |
+  Convolutional autoencoder that learns spot representations from spatial
+  transcriptomics by jointly integrating transcriptomics, morphology (H&E), and
+  spatial-neighborhood topology. The learned embeddings support downstream tasks
+  such as spatial-domain clustering and multi-modal analysis.
+project_home: https://github.com/ratschlab/aestetik
+documentation_home: https://github.com/ratschlab/aestetik#readme
+tutorials_home: https://github.com/ratschlab/aestetik/tree/main/example
+publications:
+  - 10.1093/bioinformatics/btag316
+  - 10.1101/2024.06.04.24308256
+install:
+  pypi: aestetik
+tags:
+  - spatial-omics
+  - spatial-transcriptomics
+  - representation-learning
+  - autoencoder
+  - multimodal
+  - computational-pathology
+  - deep learning
+  - pytorch
+license: MIT
+version: v0.3.1
+contact:
+  - KalinNonchev
+test_command: pip install '.[test-all]' && pytest -m "not slow"
+category: ecosystem


### PR DESCRIPTION
Adds **AESTETIK** to the scverse ecosystem.

### Mandatory

Name of the tool: AESTETIK

Short description: A convolutional autoencoder that learns spot representations from spatial transcriptomics by jointly integrating transcriptomics, morphology (H&E), and spatial-neighborhood topology. The learned embeddings support downstream tasks such as spatial-domain clustering and multi-modal analysis.

How does the package use scverse data structures (please describe in a few sentences): AESTETIK operates on `AnnData`. It consumes a spatial-transcriptomics `AnnData` (expression in `.X`, spot coordinates in `.obsm["spatial"]`, and optional per-spot morphology features), learns multi-modal spot embeddings, and writes them back into `.obsm` for downstream analysis. It builds on `anndata`, `scanpy`, and `squidpy` for the standard spatial-omics workflow.

- [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license (MIT)
- [x] The package provides versioned releases
- [x] The package can be installed from a standard registry (PyPI: `aestetik`)
- [x] Automated tests cover essential functions of the package and a reasonable range of inputs and conditions
- [x] Continuous integration (CI) automatically executes these tests on each push or pull request
- [x] The package provides API documentation via a website or README
- [x] The package uses scverse datastructures where appropriate (AnnData)
- [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website

### Recommended

- [ ] Please announce this package on scverse communication channels (zulip, discourse, twitter)
- [x] The package provides tutorials (or "vignettes") that help getting users started quickly — see [`example/`](https://github.com/ratschlab/aestetik/tree/main/example)
- [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
