### PR TITLE
Add metalsinglecell

### DIFF
--- a/packages/metalsinglecell/meta.yaml
+++ b/packages/metalsinglecell/meta.yaml
@@ -1,0 +1,24 @@
+name: metalsinglecell
+description: |
+  A Metal/MLX GPU implementation of the scanpy/squidpy single-cell analysis stack for Apple Silicon.
+  Drop-in replacements for the core scanpy (pp/tl) and squidpy (gr) functions that run on the M-series
+  GPU, plus an out-of-core streaming front-end for datasets larger than memory.
+project_home: https://github.com/gingerii/metal-SingleCell
+documentation_home: https://metal-singlecell.readthedocs.io/
+tutorials_home: https://metal-singlecell.readthedocs.io/en/latest/tutorials.html
+install:
+  pypi: metalsinglecell
+tags:
+  - GPU
+  - Apple Silicon
+  - single-cell
+  - spatial omics
+  - preprocessing
+  - clustering
+license: BSD-3-Clause
+version: v0.1.0
+contact:
+  - gingerii
+test_command: |
+  pip install -e . && pytest tests/ -m "not metal and not data"
+category: ecosystem

--- a/packages/metalsinglecell/meta.yaml
+++ b/packages/metalsinglecell/meta.yaml
@@ -5,7 +5,7 @@ description: |
   GPU, plus an out-of-core streaming front-end for datasets larger than memory.
 project_home: https://github.com/gingerii/metal-SingleCell
 documentation_home: https://metal-singlecell.readthedocs.io/
-tutorials_home: https://metal-singlecell.readthedocs.io/en/latest/tutorials.html
+tutorials_home: https://metal-singlecell.readthedocs.io/page/tutorials.html
 install:
   pypi: metalsinglecell
 tags:


### PR DESCRIPTION
# Add metalsinglecell

### Mandatory

**Name of the tool:** metalsinglecell

**Short description:** A Metal/MLX GPU implementation of the scanpy/squidpy single-cell analysis stack for Apple Silicon — drop-in replacements for the core scanpy (`pp`/`tl`) and squidpy (`gr`) functions that run on the M-series GPU, plus an out-of-core streaming front-end for datasets larger than memory.

**How does the package use scverse data structures (please describe in a few sentences):** Every function takes an `AnnData` object, computes on the GPU, and writes results back to the same slots scanpy/squidpy use (`.X`, `.obsm`, `.obsp`, `.var`, `.uns`) with scanpy's `copy=` semantics, so plotting and downstream tooling are unchanged. The API mirrors the scanpy/squidpy namespaces (`pp`, `tl`, `gr`), making it a drop-in for existing AnnData-based pipelines. The out-of-core path streams an on-disk AnnData-compatible zarr store.

- [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
- [x] The package provides versioned releases
- [x] The package can be installed from a standard registry (e.g. PyPI, conda-forge, bioconda)
- [x] Automated tests cover essential functions of the package and a reasonable range of inputs and conditions
- [x] Continuous integration (CI) automatically executes these tests on each push or pull request
- [x] The package provides API documentation via a website or README
- [x] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
- [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website

### Notes for reviewers
- License: BSD-3-Clause · PyPI: https://pypi.org/project/metalsinglecell/ · Docs: https://metal-singlecell.readthedocs.io
- Tests: `tests/` (CPU lane + self-hosted Metal-GPU lane); CI: `.github/workflows/ci.yml` (CPU lane on ubuntu + macos, incl. an "installs without mlx on Linux" contract check).
- The GPU backend (`mlx`) is a Darwin/arm64-only dependency and is lazy-imported, so the package installs and imports on any platform (CI proves this on Linux).
