### PR TITLE
fix: set browser User-Agent to avoid ReadTheDocs bot blocking

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "hatch-vcs", "hatchling" ]
 [project]
 name = "ecosystem-scripts"
 description = "scripts for ecosystem package data"
-readme = "../README.md"
+readme = "README.md"
 license = "GPL-3.0"
 authors = [
   { name = "Gregor Sturm", email = "gregor.sturm@scverse.org" },

--- a/scripts/src/ecosystem_scripts/validate_registry.py
+++ b/scripts/src/ecosystem_scripts/validate_registry.py
@@ -339,7 +339,14 @@ class Checker:
             repository=DomainBasedRateLimiterRepository()
         )
         transport = RetryTransport(transport, Retry(total=3, backoff_factor=2))
-        self.client = httpx.AsyncClient(follow_redirects=True, timeout=30.0, transport=transport)
+        # ReadTheDocs blocks requests with the default httpx user-agent; use a browser UA so
+        # that link checks reflect what a human visitor would actually experience.
+        self.client = httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=30.0,
+            transport=transport,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; scverse-ecosystem-checker/1.0)"},
+        )
 
         # using different link checkers,
         # because each of them may point to the same URL and this wouldn't qualify as duplicate


### PR DESCRIPTION
ReadTheDocs returns 403 to requests using the default httpx user-agent, causing all `readthedocs.io` link checks to fail even for valid URLs. Setting a browser-style User-Agent makes checks reflect what a human visitor actually experiences.

Unblocks #367.