### PR TITLE
Replace free-form tags with a controlled vocabulary, primary category and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ How does the package use scverse data structures (please describe in a few sente
 - [ ] Continuous integration (CI) automatically executes these tests on each push or pull request [^2]
 - [ ] The package provides API documentation via a website or README[^3]
 - [ ] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
-- [ ] `primary_category` and `tags` are set from the controlled vocabulary documented above
 - [ ] I am an author or maintainer of the tool and agree on listing the package on the scverse website
 - [ ] I agree to abide by the [scverse code of conduct](https://scverse.org/about/code_of_conduct/) on all scverse communication channels
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,42 @@ Submit a pull-request adding a `meta.yaml` file for your package to the `package
 - Please refer to other entries for examples
 - The full definition of available fields is available in [`schema.json`](scripts/src/ecosystem_scripts/schema.json)
 - You can add a logo in svg/png/webp format if you like. Currently it is not used on our website, though.
+- Please set `topics` from the controlled vocabulary below, in addition to free-form `tags`
+
+## Topics and tags
+
+Packages carry two kinds of keywords, and they do different jobs.
+
+`topics` say what a package is **for**. They come from a controlled vocabulary, are validated
+against [`schema.json`](scripts/src/ecosystem_scripts/schema.json), and drive the filters on
+[scverse.org/packages](https://scverse.org/packages/#ecosystem). Pick every topic that genuinely
+applies, usually one to three. If none of them fit your package, propose a new one in your pull
+request rather than forcing a bad match.
+
+| Topic                   | For packages that …                                                        |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `annotation`            | assign cell type or state labels, or transfer them from a reference        |
+| `cell-communication`    | infer ligand–receptor interactions and cell–cell signalling                |
+| `clustering`            | group cells, spots or genes into populations or domains                    |
+| `deconvolution`         | estimate cell type composition of mixed or bulk measurements               |
+| `differential-analysis` | test for differential expression or abundance, or score gene sets          |
+| `epigenomics`           | work with chromatin accessibility, methylation or related modalities       |
+| `gene-networks`         | infer regulatory networks, co-expression or gene programs                  |
+| `imaging`               | work with histology, microscopy or whole-slide images                      |
+| `immune`                | analyse immune receptor repertoires or are otherwise immunology-specific   |
+| `infrastructure`        | provide data structures, file formats, I/O or tooling rather than analysis |
+| `integration`           | correct batch effects, map to references, or join datasets and modalities  |
+| `multi-omics`           | jointly analyse two or more molecular modalities                           |
+| `perturbation`          | analyse CRISPR screens, drug response or other perturbation experiments    |
+| `preprocessing`         | do quality control, filtering, normalisation or denoising                  |
+| `proteomics`            | work with mass spectrometry, cytometry or other protein measurements       |
+| `spatial`               | work with spatially resolved measurements                                  |
+| `trajectory`            | infer pseudotime, RNA velocity, lineage or cell fate                       |
+| `visualization`         | provide plotting, interactive exploration or data browsers                 |
+
+`tags` stay free-form and are only used for search, so they do not need to match anyone else's
+spelling. Use them for anything the topics are too coarse to express — an assay, a method, a
+platform, a dependency.
 
 ## What are the requirements for an ecosystem package?
 
@@ -46,6 +82,7 @@ How does the package use scverse data structures (please describe in a few sente
 - [ ] Continuous integration (CI) automatically executes these tests on each push or pull request [^2]
 - [ ] The package provides API documentation via a website or README[^3]
 - [ ] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
+- [ ] The `topics` field is set from the controlled vocabulary documented above
 - [ ] I am an author or maintainer of the tool and agree on listing the package on the scverse website
 
 ### Recommended

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Pick every tag that genuinely applies.
 
 If none of the existing terms fit your package, add one to the enum in your pull request.
 
-`language` is the language you write in when using the package.
-It is assumed to be `Python` when omitted.
+`language` is the language you write in when using the package: `Python`, `R`, `Julia` or `Rust`.
 
 ## What are the requirements for an ecosystem package?
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ Submit a pull-request adding a `meta.yaml` file for your package to the `package
 
 Packages carry two kinds of keywords, and they do different jobs.
 
-`topics` say what a package is **for**. They come from a controlled vocabulary, are validated
-against [`schema.json`](scripts/src/ecosystem_scripts/schema.json), and drive the filters on
-[scverse.org/packages](https://scverse.org/packages/#ecosystem). Pick every topic that genuinely
-applies, usually one to three. If none of them fit your package, propose a new one in your pull
-request rather than forcing a bad match.
+`topics` say what a package is **for**.
+They come from a controlled vocabulary, are validated against [`schema.json`](scripts/src/ecosystem_scripts/schema.json), and drive the filters on [scverse.org/packages](https://scverse.org/packages/#ecosystem).
+Pick every topic that genuinely applies, usually one to three.
+If none of them fit your package, propose a new one in your pull request rather than forcing a bad match.
 
 | Topic                   | For packages that …                                                        |
 | ----------------------- | -------------------------------------------------------------------------- |
@@ -53,9 +52,8 @@ request rather than forcing a bad match.
 | `trajectory`            | infer pseudotime, RNA velocity, lineage or cell fate                       |
 | `visualization`         | provide plotting, interactive exploration or data browsers                 |
 
-`tags` stay free-form and are only used for search, so they do not need to match anyone else's
-spelling. Use them for anything the topics are too coarse to express — an assay, a method, a
-platform, a dependency.
+`tags` stay free-form and are only used for search, so they do not need to match anyone else's spelling.
+Use them for anything the topics are too coarse to express — an assay, a method, a platform, a dependency.
 
 ## What are the requirements for an ecosystem package?
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Submit a pull-request adding a `meta.yaml` file for your package to the `package
 
 ## Categories, tags and language
 
-Keywords are a controlled vocabulary rather than free text, so that the same concept is not spelled three different ways across the registry.
-The vocabulary is defined in [`schema.json`](scripts/src/ecosystem_scripts/schema.json) and validated in CI, and it deliberately overlaps with the one used by the [tutorial registry](https://github.com/scverse/scverse-tutorials/blob/main/tutorial-registry/schema.json).
+Keywords come from a controlled vocabulary, defined in [`schema.json`](scripts/src/ecosystem_scripts/schema.json) and validated in CI.
+It overlaps with the vocabulary used by the [tutorial registry](https://github.com/scverse/scverse-tutorials/blob/main/tutorial-registry/schema.json).
 
 `primary_category` is the single category your package is listed under on [scverse.org/packages](https://scverse.org/packages/#ecosystem).
 Pick the one a user looking for your package would browse first.
@@ -49,11 +49,10 @@ Pick every tag that genuinely applies.
 - **How it is built** — `deep learning`, `foundation model`, `large language models`, `probabilistic modeling`, `optimal transport`, `GPU acceleration`, `pipeline`
 - **Project shape** — `data structures`, `interoperability`, `file formats`, `documentation`
 
-If none of the existing terms fit your package, add one to the enum in your pull request and say why.
-That is a deliberate speed bump: it keeps the vocabulary small enough to be useful, while letting it grow when the science does.
+If none of the existing terms fit your package, add one to the enum in your pull request.
 
 `language` is the language you write in when using the package.
-It is assumed to be `Python` when omitted, so only set it if that is wrong.
+It is assumed to be `Python` when omitted.
 
 ## What are the requirements for an ecosystem package?
 

--- a/README.md
+++ b/README.md
@@ -20,46 +20,48 @@ Submit a pull-request adding a `meta.yaml` file for your package to the `package
 - Please refer to other entries for examples
 - The full definition of available fields is available in [`schema.json`](scripts/src/ecosystem_scripts/schema.json)
 - You can add a logo in svg/png/webp format if you like. Currently it is not used on our website, though.
-- Please set `topics` from the controlled vocabulary below, in addition to free-form `tags`
+- Please set `primary_category` and `tags` from the controlled vocabulary below
 
-## Topics and tags
+## Categories, tags and language
 
-Packages carry two kinds of keywords, and they do different jobs.
+Keywords are a controlled vocabulary rather than free text, so that the same concept is not spelled three different ways across the registry.
+The vocabulary is defined in [`schema.json`](scripts/src/ecosystem_scripts/schema.json) and validated in CI, and it deliberately overlaps with the one used by the [tutorial registry](https://github.com/scverse/scverse-tutorials/blob/main/tutorial-registry/schema.json).
 
-`topics` say what a package is **for**.
-They come from a controlled vocabulary, are validated against [`schema.json`](scripts/src/ecosystem_scripts/schema.json), and drive the filters on [scverse.org/packages](https://scverse.org/packages/#ecosystem).
-Pick every topic that genuinely applies, usually one to three.
-If none of them fit your package, propose a new one in your pull request rather than forcing a bad match.
+`primary_category` is the single category your package is listed under on [scverse.org/packages](https://scverse.org/packages/#ecosystem).
+Pick the one a user looking for your package would browse first.
 
-| Topic                   | For packages that …                                                        |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `annotation`            | assign cell type or state labels, or transfer them from a reference        |
-| `cell-communication`    | infer ligand–receptor interactions and cell–cell signalling                |
-| `clustering`            | group cells, spots or genes into populations or domains                    |
-| `deconvolution`         | estimate cell type composition of mixed or bulk measurements               |
-| `differential-analysis` | test for differential expression or abundance, or score gene sets          |
-| `epigenomics`           | work with chromatin accessibility, methylation or related modalities       |
-| `gene-networks`         | infer regulatory networks, co-expression or gene programs                  |
-| `imaging`               | work with histology, microscopy or whole-slide images                      |
-| `immune`                | analyse immune receptor repertoires or are otherwise immunology-specific   |
-| `infrastructure`        | provide data structures, file formats, I/O or tooling rather than analysis |
-| `integration`           | correct batch effects, map to references, or join datasets and modalities  |
-| `multi-omics`           | jointly analyse two or more molecular modalities                           |
-| `perturbation`          | analyse CRISPR screens, drug response or other perturbation experiments    |
-| `preprocessing`         | do quality control, filtering, normalisation or denoising                  |
-| `proteomics`            | work with mass spectrometry, cytometry or other protein measurements       |
-| `spatial`               | work with spatially resolved measurements                                  |
-| `trajectory`            | infer pseudotime, RNA velocity, lineage or cell fate                       |
-| `visualization`         | provide plotting, interactive exploration or data browsers                 |
+- `Data structures`
+- `scRNA-seq`
+- `bulk RNA-seq`
+- `Spatial`
+- `Epigenomics`
+- `Proteomics`
+- `Adaptive immune cell receptor`
+- `Multimodal`
+- `Imaging`
+- `Infrastructure`
 
-`tags` stay free-form and are only used for search, so they do not need to match anyone else's spelling.
-Use them for anything the topics are too coarse to express — an assay, a method, a platform, a dependency.
+`tags` say what the package does, and drive filtering and search on the website.
+Pick every tag that genuinely applies.
+
+- **Data and modality** — `scRNA-seq`, `bulk RNA-seq`, `spatial transcriptomics`, `spatial proteomics`, `proteomics`, `flow cytometry`, `ATAC-seq`, `epigenomics`, `immune receptor`, `imaging`, `multimodal`
+- **Analysis step** — `preprocessing`, `quality control`, `denoising`, `data integration`, `cell-type annotation`, `differential expression`, `compositional analysis`, `functional analysis`, `gene regulatory networks`, `cell-cell communication`, `deconvolution`, `clustering`, `dimensionality reduction`, `trajectory inference`, `pseudotime`, `RNA velocity`, `lineage tracing`, `perturbation`, `spatially variable genes`, `segmentation`, `copy number variation`, `visualization`, `benchmarking`
+- **How it is built** — `deep learning`, `foundation model`, `large language models`, `probabilistic modeling`, `optimal transport`, `GPU acceleration`, `pipeline`
+- **Project shape** — `data structures`, `interoperability`, `file formats`, `documentation`
+
+If none of the existing terms fit your package, add one to the enum in your pull request and say why.
+That is a deliberate speed bump: it keeps the vocabulary small enough to be useful, while letting it grow when the science does.
+
+`language` is the language you write in when using the package.
+It is assumed to be `Python` when omitted, so only set it if that is wrong.
 
 ## What are the requirements for an ecosystem package?
 
 For a package to become an approved ecosystem package, it must fulfill all mandatory requirements from the checklist below.
 
 Ecosystem packages can be written in non-Python languages as long as they fulfill the above requirements.
+
+Authors of ecosystem packages agree to abide by the [scverse code of conduct](https://scverse.org/about/code_of_conduct/) on all scverse communication channels.
 
 If you cannot or do not want to comply with these requirements, you are still free to make your package interoperable with scverse by using our datastructures, but we will not list your package on our ecosystem page.
 
@@ -80,8 +82,9 @@ How does the package use scverse data structures (please describe in a few sente
 - [ ] Continuous integration (CI) automatically executes these tests on each push or pull request [^2]
 - [ ] The package provides API documentation via a website or README[^3]
 - [ ] The package uses scverse datastructures where appropriate (i.e. AnnData, MuData or SpatialData and their modality-specific extensions)
-- [ ] The `topics` field is set from the controlled vocabulary documented above
+- [ ] `primary_category` and `tags` are set from the controlled vocabulary documented above
 - [ ] I am an author or maintainer of the tool and agree on listing the package on the scverse website
+- [ ] I agree to abide by the [scverse code of conduct](https://scverse.org/about/code_of_conduct/) on all scverse communication channels
 
 ### Recommended
 

--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -12,19 +12,13 @@ publications:
   - 10.1101/2024.06.04.24308256
 install:
   pypi: aestetik
+primary_category: Spatial
 tags:
-  - spatial-omics
-  - spatial-transcriptomics
-  - representation-learning
-  - autoencoder
-  - multimodal
-  - computational-pathology
-  - deep learning
-  - pytorch
-topics:
-  - spatial
+  - spatial transcriptomics
   - imaging
-  - multi-omics
+  - multimodal
+  - dimensionality reduction
+  - deep learning
 license: MIT
 version: v0.3.1
 contact:

--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -20,6 +20,7 @@ tags:
   - dimensionality reduction
   - deep learning
 license: MIT
+language: Python
 version: v0.3.1
 contact:
   - KalinNonchev

--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -21,6 +21,10 @@ tags:
   - computational-pathology
   - deep learning
   - pytorch
+topics:
+  - spatial
+  - imaging
+  - multi-omics
 license: MIT
 version: v0.3.1
 contact:

--- a/packages/CellAnnotator/meta.yaml
+++ b/packages/CellAnnotator/meta.yaml
@@ -10,6 +10,7 @@ tags:
   - cell-type annotation
   - large language models
 license: MIT
+language: Python
 version: v0.1.3
 contact:
   - Marius1311

--- a/packages/CellAnnotator/meta.yaml
+++ b/packages/CellAnnotator/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - large language models
   - automatic annotation
   - cell state
+topics:
+  - annotation
 license: MIT
 version: v0.1.3
 contact:

--- a/packages/CellAnnotator/meta.yaml
+++ b/packages/CellAnnotator/meta.yaml
@@ -5,14 +5,10 @@ project_home: https://github.com/quadbio/cell-annotator
 documentation_home: https://cell-annotator.readthedocs.io/
 install:
   pypi: cell-annotator
+primary_category: scRNA-seq
 tags:
-  - cell type labels
-  - openai
+  - cell-type annotation
   - large language models
-  - automatic annotation
-  - cell state
-topics:
-  - annotation
 license: MIT
 version: v0.1.3
 contact:

--- a/packages/CellCharter/meta.yaml
+++ b/packages/CellCharter/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - clustering
   - probabilistic modeling
 license: BSD-3-Clause
+language: Python
 version: v0.3.1
 contact:
   - marcovarrone

--- a/packages/CellCharter/meta.yaml
+++ b/packages/CellCharter/meta.yaml
@@ -13,6 +13,10 @@ tags:
   - spatial clustering
   - spatial domains
   - gaussian mixture model
+topics:
+  - spatial
+  - multi-omics
+  - clustering
 license: BSD-3-Clause
 version: v0.3.1
 contact:

--- a/packages/CellCharter/meta.yaml
+++ b/packages/CellCharter/meta.yaml
@@ -8,15 +8,11 @@ publications:
   - 10.1038/s41588-023-01588-4
 install:
   pypi: cellcharter
+primary_category: Spatial
 tags:
-  - spatial omics
-  - spatial clustering
-  - spatial domains
-  - gaussian mixture model
-topics:
-  - spatial
-  - multi-omics
+  - spatial transcriptomics
   - clustering
+  - probabilistic modeling
 license: BSD-3-Clause
 version: v0.3.1
 contact:

--- a/packages/CellMapper/meta.yaml
+++ b/packages/CellMapper/meta.yaml
@@ -5,14 +5,10 @@ project_home: https://github.com/quadbio/cellmapper
 documentation_home: https://cellmapper.readthedocs.io/
 install:
   pypi: cellmapper
+primary_category: scRNA-seq
 tags:
-  - k-NN based mapping
-  - rapids
-  - faiss
-  - query-to-reference
-topics:
-  - integration
-  - annotation
+  - data integration
+  - GPU acceleration
 license: MIT
 version: v0.1.2
 contact:

--- a/packages/CellMapper/meta.yaml
+++ b/packages/CellMapper/meta.yaml
@@ -10,6 +10,9 @@ tags:
   - rapids
   - faiss
   - query-to-reference
+topics:
+  - integration
+  - annotation
 license: MIT
 version: v0.1.2
 contact:

--- a/packages/CellMapper/meta.yaml
+++ b/packages/CellMapper/meta.yaml
@@ -10,6 +10,7 @@ tags:
   - data integration
   - GPU acceleration
 license: MIT
+language: Python
 version: v0.1.2
 contact:
   - Marius1311

--- a/packages/CellOracle/meta.yaml
+++ b/packages/CellOracle/meta.yaml
@@ -9,12 +9,10 @@ publications:
   - 10.1101/2020.02.17.947416
 install:
   pypi: celloracle
+primary_category: Epigenomics
 tags:
-  - GRN
-  - TF
-topics:
-  - gene-networks
   - epigenomics
+  - gene regulatory networks
   - perturbation
 license: Apache-2.0
 version: v0.10.12

--- a/packages/CellOracle/meta.yaml
+++ b/packages/CellOracle/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - gene regulatory networks
   - perturbation
 license: Apache-2.0
+language: Python
 version: v0.10.12
 contact:
   - KenjiKamimoto-ac

--- a/packages/CellOracle/meta.yaml
+++ b/packages/CellOracle/meta.yaml
@@ -12,6 +12,10 @@ install:
 tags:
   - GRN
   - TF
+topics:
+  - gene-networks
+  - epigenomics
+  - perturbation
 license: Apache-2.0
 version: v0.10.12
 contact:

--- a/packages/CellRank/meta.yaml
+++ b/packages/CellRank/meta.yaml
@@ -10,13 +10,11 @@ publications:
   - 10.1038/s41592-021-01346-6
 install:
   pypi: cellrank
+primary_category: scRNA-seq
 tags:
-  - ML
-  - cell-fate
-  - rna-velocity
-  - trajectory-generation
-topics:
-  - trajectory
+  - trajectory inference
+  - RNA velocity
+  - deep learning
 license: BSD-3-Clause
 version: v1.5.1
 contact:

--- a/packages/CellRank/meta.yaml
+++ b/packages/CellRank/meta.yaml
@@ -15,6 +15,8 @@ tags:
   - cell-fate
   - rna-velocity
   - trajectory-generation
+topics:
+  - trajectory
 license: BSD-3-Clause
 version: v1.5.1
 contact:

--- a/packages/CellRank/meta.yaml
+++ b/packages/CellRank/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - RNA velocity
   - deep learning
 license: BSD-3-Clause
+language: Python
 version: v1.5.1
 contact:
   - Marius1311

--- a/packages/Cell_BLAST/meta.yaml
+++ b/packages/Cell_BLAST/meta.yaml
@@ -9,6 +9,8 @@ install:
   pypi: Cell-BLAST
 tags:
   - BLAST
+topics:
+  - annotation
 license: MIT
 version: v0.3.8
 contact:

--- a/packages/Cell_BLAST/meta.yaml
+++ b/packages/Cell_BLAST/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - data integration
   - cell-type annotation
 license: MIT
+language: Python
 version: v0.3.8
 contact:
   - Jeff1995

--- a/packages/Cell_BLAST/meta.yaml
+++ b/packages/Cell_BLAST/meta.yaml
@@ -7,10 +7,10 @@ publications:
   - 10.1038/s41467-020-17281-7
 install:
   pypi: Cell-BLAST
+primary_category: scRNA-seq
 tags:
-  - BLAST
-topics:
-  - annotation
+  - data integration
+  - cell-type annotation
 license: MIT
 version: v0.3.8
 contact:

--- a/packages/CellphoneDB/meta.yaml
+++ b/packages/CellphoneDB/meta.yaml
@@ -18,6 +18,8 @@ tags:
   - single-cell
   - python
   - jupyter
+topics:
+  - cell-communication
 license: MIT
 version: v5.0.0
 contact:

--- a/packages/CellphoneDB/meta.yaml
+++ b/packages/CellphoneDB/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - scRNA-seq
   - cell-cell communication
 license: MIT
+language: Python
 version: v5.0.0
 contact:
   - chapuzzo

--- a/packages/CellphoneDB/meta.yaml
+++ b/packages/CellphoneDB/meta.yaml
@@ -11,15 +11,10 @@ publications:
   - 10.1038/s41586-022-04918-4
 install:
   pypi: cellphonedb
+primary_category: scRNA-seq
 tags:
   - scRNA-seq
   - cell-cell communication
-  - ligand-receptor
-  - single-cell
-  - python
-  - jupyter
-topics:
-  - cell-communication
 license: MIT
 version: v5.0.0
 contact:

--- a/packages/Cirrocumulus/meta.yaml
+++ b/packages/Cirrocumulus/meta.yaml
@@ -12,6 +12,7 @@ primary_category: scRNA-seq
 tags:
   - visualization
 license: BSD-3-Clause
+language: Python
 version: v1.1.41
 contact:
   - joshua-gould

--- a/packages/Cirrocumulus/meta.yaml
+++ b/packages/Cirrocumulus/meta.yaml
@@ -10,6 +10,8 @@ install:
   pypi: cirrocumulus
 tags:
   - visualization
+topics:
+  - visualization
 license: BSD-3-Clause
 version: v1.1.41
 contact:

--- a/packages/Cirrocumulus/meta.yaml
+++ b/packages/Cirrocumulus/meta.yaml
@@ -8,9 +8,8 @@ publications:
   - 10.1038/s41592-020-0905-x
 install:
   pypi: cirrocumulus
+primary_category: scRNA-seq
 tags:
-  - visualization
-topics:
   - visualization
 license: BSD-3-Clause
 version: v1.1.41

--- a/packages/DOTools_py/meta.yaml
+++ b/packages/DOTools_py/meta.yaml
@@ -10,6 +10,8 @@ tags:
   - python
   - visualisation
   - analysis
+topics:
+  - visualization
 license: MIT
 version: v0.0.2
 contact:

--- a/packages/DOTools_py/meta.yaml
+++ b/packages/DOTools_py/meta.yaml
@@ -10,6 +10,7 @@ tags:
   - scRNA-seq
   - visualization
 license: MIT
+language: Python
 version: v0.0.2
 contact:
   - davidrm-bio

--- a/packages/DOTools_py/meta.yaml
+++ b/packages/DOTools_py/meta.yaml
@@ -5,12 +5,9 @@ documentation_home: https://dotools-py.readthedocs.io/
 tutorials_home: https://dotools-py.readthedocs.io/
 install:
   pypi: DOtools-py
+primary_category: scRNA-seq
 tags:
   - scRNA-seq
-  - python
-  - visualisation
-  - analysis
-topics:
   - visualization
 license: MIT
 version: v0.0.2

--- a/packages/DRVI/meta.yaml
+++ b/packages/DRVI/meta.yaml
@@ -12,14 +12,12 @@ publications:
   - 10.1101/2024.11.06.622266
 install:
   pypi: drvi-py
+primary_category: scRNA-seq
 tags:
-  - disentanglement
-  - interpretability
   - data integration
-  - variational inference
+  - dimensionality reduction
   - deep learning
-topics:
-  - integration
+  - probabilistic modeling
 license: BSD-3-Clause
 version: 0.2.0
 contact:

--- a/packages/DRVI/meta.yaml
+++ b/packages/DRVI/meta.yaml
@@ -18,6 +18,8 @@ tags:
   - data integration
   - variational inference
   - deep learning
+topics:
+  - integration
 license: BSD-3-Clause
 version: 0.2.0
 contact:

--- a/packages/DRVI/meta.yaml
+++ b/packages/DRVI/meta.yaml
@@ -19,6 +19,7 @@ tags:
   - deep learning
   - probabilistic modeling
 license: BSD-3-Clause
+language: Python
 version: 0.2.0
 contact:
   - moinfar

--- a/packages/DoubletDetection/meta.yaml
+++ b/packages/DoubletDetection/meta.yaml
@@ -9,10 +9,9 @@ publications:
   - 10.1016/j.cels.2019.03.003
 install:
   pypi: doubletdetection
+primary_category: scRNA-seq
 tags:
-  - doublet
-topics:
-  - preprocessing
+  - quality control
 license: MIT
 version: v4.2
 contact:

--- a/packages/DoubletDetection/meta.yaml
+++ b/packages/DoubletDetection/meta.yaml
@@ -13,6 +13,7 @@ primary_category: scRNA-seq
 tags:
   - quality control
 license: MIT
+language: Python
 version: v4.2
 contact:
   - adamgayoso

--- a/packages/DoubletDetection/meta.yaml
+++ b/packages/DoubletDetection/meta.yaml
@@ -11,6 +11,8 @@ install:
   pypi: doubletdetection
 tags:
   - doublet
+topics:
+  - preprocessing
 license: MIT
 version: v4.2
 contact:

--- a/packages/GPTBioInsightor/meta.yaml
+++ b/packages/GPTBioInsightor/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - bioinformatics
   - LLM
   - AI
+topics:
+  - annotation
 license: BSD-3-Clause
 version: v0.3.0
 contact:

--- a/packages/GPTBioInsightor/meta.yaml
+++ b/packages/GPTBioInsightor/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - deep learning
   - large language models
 license: BSD-3-Clause
+language: Python
 version: v0.3.0
 contact:
   - huangsh

--- a/packages/GPTBioInsightor/meta.yaml
+++ b/packages/GPTBioInsightor/meta.yaml
@@ -6,13 +6,10 @@ project_home: https://github.com/huang-sh/GPTBioInsightor
 documentation_home: https://gptbioinsightor.readthedocs.io/
 install:
   pypi: gptbioinsightor
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - bioinformatics
-  - LLM
-  - AI
-topics:
-  - annotation
+  - deep learning
+  - large language models
 license: BSD-3-Clause
 version: v0.3.0
 contact:

--- a/packages/GRnnData/meta.yaml
+++ b/packages/GRnnData/meta.yaml
@@ -14,6 +14,9 @@ tags:
   - gene networks
   - format
   - utilities
+topics:
+  - gene-networks
+  - infrastructure
 license: MIT
 version: v1.1.4
 contact:

--- a/packages/GRnnData/meta.yaml
+++ b/packages/GRnnData/meta.yaml
@@ -8,15 +8,11 @@ publications:
   - 10.1101/2024.07.29.605556
 install:
   pypi: grnndata
+primary_category: Data structures
 tags:
-  - single cell
-  - RNAseq
-  - gene networks
-  - format
-  - utilities
-topics:
-  - gene-networks
-  - infrastructure
+  - scRNA-seq
+  - gene regulatory networks
+  - file formats
 license: MIT
 version: v1.1.4
 contact:

--- a/packages/GRnnData/meta.yaml
+++ b/packages/GRnnData/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - gene regulatory networks
   - file formats
 license: MIT
+language: Python
 version: v1.1.4
 contact:
   - jkobject

--- a/packages/LazySlide/meta.yaml
+++ b/packages/LazySlide/meta.yaml
@@ -9,6 +9,9 @@ tags:
   - Pathology
   - Whole Slide Imaging
   - PyTorch
+topics:
+  - imaging
+  - preprocessing
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/LazySlide/meta.yaml
+++ b/packages/LazySlide/meta.yaml
@@ -5,13 +5,12 @@ project_home: https://github.com/rendeirolab/lazyslide
 documentation_home: https://lazyslide.readthedocs.io/
 install:
   pypi: lazyslide
+primary_category: Imaging
 tags:
-  - Pathology
-  - Whole Slide Imaging
-  - PyTorch
-topics:
   - imaging
   - preprocessing
+  - segmentation
+  - deep learning
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/LazySlide/meta.yaml
+++ b/packages/LazySlide/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - segmentation
   - deep learning
 license: MIT
+language: Python
 version: v0.3.0
 contact:
   - Mr-Milk

--- a/packages/Mowgli/meta.yaml
+++ b/packages/Mowgli/meta.yaml
@@ -7,15 +7,12 @@ publications:
   - 10.1101/2023.02.02.526825
 install:
   pypi: mowgli
+primary_category: Multimodal
 tags:
-  - single cell
-  - optimal transport
-  - multi omics
+  - multimodal
   - data integration
-  - NMF
-topics:
-  - multi-omics
-  - integration
+  - dimensionality reduction
+  - optimal transport
 license: GPL-3.0-only
 version: v0.2.0
 contact:

--- a/packages/Mowgli/meta.yaml
+++ b/packages/Mowgli/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - dimensionality reduction
   - optimal transport
 license: GPL-3.0-only
+language: Python
 version: v0.2.0
 contact:
   - gjhuizing

--- a/packages/Mowgli/meta.yaml
+++ b/packages/Mowgli/meta.yaml
@@ -13,6 +13,9 @@ tags:
   - multi omics
   - data integration
   - NMF
+topics:
+  - multi-omics
+  - integration
 license: GPL-3.0-only
 version: v0.2.0
 contact:

--- a/packages/Multivelo/meta.yaml
+++ b/packages/Multivelo/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - epigenomics
   - RNA velocity
 license: BSD-3-Clause
+language: Python
 version: 0.1.3
 contact:
   - jw156605

--- a/packages/Multivelo/meta.yaml
+++ b/packages/Multivelo/meta.yaml
@@ -9,11 +9,10 @@ publications:
   - 10.1038/s41587-022-01476-y
 install:
   pypi: multivelo
+primary_category: Epigenomics
 tags:
-  - rna velocity
-topics:
-  - trajectory
   - epigenomics
+  - RNA velocity
 license: BSD-3-Clause
 version: 0.1.3
 contact:

--- a/packages/Multivelo/meta.yaml
+++ b/packages/Multivelo/meta.yaml
@@ -11,6 +11,9 @@ install:
   pypi: multivelo
 tags:
   - rna velocity
+topics:
+  - trajectory
+  - epigenomics
 license: BSD-3-Clause
 version: 0.1.3
 contact:

--- a/packages/PEAKQC/meta.yaml
+++ b/packages/PEAKQC/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - ATAC-seq
   - quality control
 license: MIT
+language: Python
 version: 0.1.3
 contact:
   - mlooso

--- a/packages/PEAKQC/meta.yaml
+++ b/packages/PEAKQC/meta.yaml
@@ -10,6 +10,9 @@ tags:
   - single cell
   - ATAC-seq
   - quality control
+topics:
+  - epigenomics
+  - preprocessing
 license: MIT
 version: 0.1.3
 contact:

--- a/packages/PEAKQC/meta.yaml
+++ b/packages/PEAKQC/meta.yaml
@@ -6,13 +6,10 @@ publications:
   - 10.1101/2025.02.20.639146
 install:
   pypi: peakqc
+primary_category: Epigenomics
 tags:
-  - single cell
   - ATAC-seq
   - quality control
-topics:
-  - epigenomics
-  - preprocessing
 license: MIT
 version: 0.1.3
 contact:

--- a/packages/PILOT/meta.yaml
+++ b/packages/PILOT/meta.yaml
@@ -15,16 +15,12 @@ install:
     # Install the PILOT package from PyPI
     pip install pilotpy
   pypi: pilotpy
+primary_category: Multimodal
 tags:
-  - multi-omics
-  - single-cell
-  - trajectory
-  - pathomics-data
-  - ot
-  - patient-level
-topics:
-  - trajectory
-  - multi-omics
+  - imaging
+  - multimodal
+  - trajectory inference
+  - optimal transport
 license: MIT
 version: v2.0.6
 contact:

--- a/packages/PILOT/meta.yaml
+++ b/packages/PILOT/meta.yaml
@@ -22,6 +22,9 @@ tags:
   - pathomics-data
   - ot
   - patient-level
+topics:
+  - trajectory
+  - multi-omics
 license: MIT
 version: v2.0.6
 contact:

--- a/packages/PILOT/meta.yaml
+++ b/packages/PILOT/meta.yaml
@@ -22,6 +22,7 @@ tags:
   - trajectory inference
   - optimal transport
 license: MIT
+language: Python
 version: v2.0.6
 contact:
   - mehdijoodaki

--- a/packages/ParTIpy/meta.yaml
+++ b/packages/ParTIpy/meta.yaml
@@ -7,14 +7,9 @@ tutorials_home: https://partipy.readthedocs.io/
 install:
   pypi: partipy
 license: MIT
+primary_category: scRNA-seq
 tags:
-  - "single cell"
-  - "archetypal analysis"
-  - "division of labor"
-  - "representation learning"
-topics:
-  - clustering
-  - spatial
+  - dimensionality reduction
 version: v0.0.04
 contact:
   - psl-schaefer

--- a/packages/ParTIpy/meta.yaml
+++ b/packages/ParTIpy/meta.yaml
@@ -12,6 +12,9 @@ tags:
   - "archetypal analysis"
   - "division of labor"
   - "representation learning"
+topics:
+  - clustering
+  - spatial
 version: v0.0.04
 contact:
   - psl-schaefer

--- a/packages/ParTIpy/meta.yaml
+++ b/packages/ParTIpy/meta.yaml
@@ -7,6 +7,7 @@ tutorials_home: https://partipy.readthedocs.io/
 install:
   pypi: partipy
 license: MIT
+language: Python
 primary_category: scRNA-seq
 tags:
   - dimensionality reduction

--- a/packages/PathML/meta.yaml
+++ b/packages/PathML/meta.yaml
@@ -12,6 +12,7 @@ primary_category: Imaging
 tags:
   - imaging
 license: GPL-2.0-only
+language: Python
 version: v2.1.0
 contact:
   - jacob-rosenthal

--- a/packages/PathML/meta.yaml
+++ b/packages/PathML/meta.yaml
@@ -10,6 +10,8 @@ install:
   pypi: pathml
 tags:
   - pathology
+topics:
+  - imaging
 license: GPL-2.0-only
 version: v2.1.0
 contact:

--- a/packages/PathML/meta.yaml
+++ b/packages/PathML/meta.yaml
@@ -8,9 +8,8 @@ publications:
   - 10.1158/1541-7786.MCR-21-0665
 install:
   pypi: pathml
+primary_category: Imaging
 tags:
-  - pathology
-topics:
   - imaging
 license: GPL-2.0-only
 version: v2.1.0

--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -8,6 +8,7 @@ tutorials_home: https://pydeseq2.readthedocs.io/page/auto_examples/
 install:
   pypi: pydeseq2
 license: MIT
+language: Python
 primary_category: bulk RNA-seq
 tags:
   - bulk RNA-seq

--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -11,6 +11,8 @@ license: MIT
 tags:
   - rna-seq
   - differential-expression
+topics:
+  - differential-analysis
 publications:
   - 10.1101/2022.12.14.520412
 version: v0.3.0

--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -8,11 +8,10 @@ tutorials_home: https://pydeseq2.readthedocs.io/page/auto_examples/
 install:
   pypi: pydeseq2
 license: MIT
+primary_category: bulk RNA-seq
 tags:
-  - rna-seq
-  - differential-expression
-topics:
-  - differential-analysis
+  - bulk RNA-seq
+  - differential expression
 publications:
   - 10.1101/2022.12.14.520412
 version: v0.3.0

--- a/packages/Rectangle/meta.yaml
+++ b/packages/Rectangle/meta.yaml
@@ -8,6 +8,7 @@ tutorials_home: https://rectanglepy.readthedocs.io/notebooks/example.html
 install:
   pypi: rectanglepy
 license: MIT
+language: Python
 primary_category: bulk RNA-seq
 tags:
   - bulk RNA-seq

--- a/packages/Rectangle/meta.yaml
+++ b/packages/Rectangle/meta.yaml
@@ -11,6 +11,8 @@ license: MIT
 tags:
   - rna-seq
   - deconvolution
+topics:
+  - deconvolution
 version: v0.1.6
 contact:
   - bernheder

--- a/packages/Rectangle/meta.yaml
+++ b/packages/Rectangle/meta.yaml
@@ -8,10 +8,9 @@ tutorials_home: https://rectanglepy.readthedocs.io/notebooks/example.html
 install:
   pypi: rectanglepy
 license: MIT
+primary_category: bulk RNA-seq
 tags:
-  - rna-seq
-  - deconvolution
-topics:
+  - bulk RNA-seq
   - deconvolution
 version: v0.1.6
 contact:

--- a/packages/SC2Spa/meta.yaml
+++ b/packages/SC2Spa/meta.yaml
@@ -9,15 +9,12 @@ project_home: https://github.com/linbuliao/SC2Spa
 documentation_home: https://sc2spa.readthedocs.io/
 install:
   pypi: SC2Spa
+primary_category: Spatial
 tags:
-  - spatial inference
   - scRNA-seq
   - spatial transcriptomics
+  - cell-cell communication
   - deep learning
-  - cell communication
-topics:
-  - spatial
-  - integration
 license: BSD-3-Clause
 version: v1.2
 contact:

--- a/packages/SC2Spa/meta.yaml
+++ b/packages/SC2Spa/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - cell-cell communication
   - deep learning
 license: BSD-3-Clause
+language: Python
 version: v1.2
 contact:
   - linbuliao

--- a/packages/SC2Spa/meta.yaml
+++ b/packages/SC2Spa/meta.yaml
@@ -15,6 +15,9 @@ tags:
   - spatial transcriptomics
   - deep learning
   - cell communication
+topics:
+  - spatial
+  - integration
 license: BSD-3-Clause
 version: v1.2
 contact:

--- a/packages/SCALEX/meta.yaml
+++ b/packages/SCALEX/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - ATAC-seq
   - data integration
 license: MIT
+language: Python
 version: v1.0.3
 contact:
   - jsxlei

--- a/packages/SCALEX/meta.yaml
+++ b/packages/SCALEX/meta.yaml
@@ -12,6 +12,9 @@ tags:
   - integration
   - projection
   - scATAC-seq
+topics:
+  - integration
+  - epigenomics
 license: MIT
 version: v1.0.3
 contact:

--- a/packages/SCALEX/meta.yaml
+++ b/packages/SCALEX/meta.yaml
@@ -7,14 +7,11 @@ publications:
   - 10.1038/s41467-022-33758-z
 install:
   pypi: SCALEX
+primary_category: Multimodal
 tags:
   - scRNA-seq
-  - integration
-  - projection
-  - scATAC-seq
-topics:
-  - integration
-  - epigenomics
+  - ATAC-seq
+  - data integration
 license: MIT
 version: v1.0.3
 contact:

--- a/packages/STMiner/meta.yaml
+++ b/packages/STMiner/meta.yaml
@@ -5,13 +5,12 @@ project_home: https://github.com/xjtu-omics/STMiner
 documentation_home: https://stminerdoc.readthedocs.io/
 install:
   pypi: stminer
+primary_category: Spatial
 tags:
-  - spatial variable genes
-  - spatial patterns
+  - spatial transcriptomics
+  - spatially variable genes
+  - deep learning
   - optimal transport
-  - mechine learning
-topics:
-  - spatial
 license: GPL-3.0-or-later
 version: v1.1.0
 contact:

--- a/packages/STMiner/meta.yaml
+++ b/packages/STMiner/meta.yaml
@@ -10,6 +10,8 @@ tags:
   - spatial patterns
   - optimal transport
   - mechine learning
+topics:
+  - spatial
 license: GPL-3.0-or-later
 version: v1.1.0
 contact:

--- a/packages/STMiner/meta.yaml
+++ b/packages/STMiner/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - deep learning
   - optimal transport
 license: GPL-3.0-or-later
+language: Python
 version: v1.1.0
 contact:
   - PSSUN

--- a/packages/SnapATAC2/meta.yaml
+++ b/packages/SnapATAC2/meta.yaml
@@ -11,14 +11,10 @@ publications:
 install:
   pypi: snapatac2
   conda: bioconda::snapatac2
+primary_category: Epigenomics
 tags:
   - ATAC-seq
-  - chromatin accessibility
   - epigenomics
-topics:
-  - epigenomics
-  - preprocessing
-  - clustering
 license: MIT
 version: 2.5.0
 contact:

--- a/packages/SnapATAC2/meta.yaml
+++ b/packages/SnapATAC2/meta.yaml
@@ -15,6 +15,10 @@ tags:
   - ATAC-seq
   - chromatin accessibility
   - epigenomics
+topics:
+  - epigenomics
+  - preprocessing
+  - clustering
 license: MIT
 version: 2.5.0
 contact:

--- a/packages/SnapATAC2/meta.yaml
+++ b/packages/SnapATAC2/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - ATAC-seq
   - epigenomics
 license: MIT
+language: Python
 version: 2.5.0
 contact:
   - kaizhang

--- a/packages/TreeData/meta.yaml
+++ b/packages/TreeData/meta.yaml
@@ -9,6 +9,9 @@ install:
   pypi: treedata
 tags:
   - lineage-tracing
+topics:
+  - infrastructure
+  - trajectory
 license: BSD-3-Clause
 version: v0.2.2
 contact:

--- a/packages/TreeData/meta.yaml
+++ b/packages/TreeData/meta.yaml
@@ -7,11 +7,10 @@ documentation_home: https://treedata.readthedocs.io/
 tutorials_home: https://treedata.readthedocs.io/
 install:
   pypi: treedata
+primary_category: Data structures
 tags:
-  - lineage-tracing
-topics:
-  - infrastructure
-  - trajectory
+  - lineage tracing
+  - data structures
 license: BSD-3-Clause
 version: v0.2.2
 contact:

--- a/packages/TreeData/meta.yaml
+++ b/packages/TreeData/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - lineage tracing
   - data structures
 license: BSD-3-Clause
+language: Python
 version: v0.2.2
 contact:
   - colganwi

--- a/packages/alphapepttools/meta.yaml
+++ b/packages/alphapepttools/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - proteomics
   - file formats
 license: Apache-2.0
+language: Python
 version: 0.2.0
 contact:
   - vbrennsteiner

--- a/packages/alphapepttools/meta.yaml
+++ b/packages/alphapepttools/meta.yaml
@@ -14,6 +14,9 @@ tags:
   - proteomics
   - annotated data
   - best practices
+topics:
+  - proteomics
+  - infrastructure
 license: Apache-2.0
 version: 0.2.0
 contact:

--- a/packages/alphapepttools/meta.yaml
+++ b/packages/alphapepttools/meta.yaml
@@ -10,13 +10,10 @@ documentation_home: https://mannlabs.github.io/alphapepttools/index.html
 tutorials_home: https://github.com/MannLabs/alphapepttools/tree/main/docs/notebooks
 install:
   pypi: alphapepttools
+primary_category: Proteomics
 tags:
   - proteomics
-  - annotated data
-  - best practices
-topics:
-  - proteomics
-  - infrastructure
+  - file formats
 license: Apache-2.0
 version: 0.2.0
 contact:

--- a/packages/anndata-for-R/meta.yaml
+++ b/packages/anndata-for-R/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - data structures
   - interoperability
   - R
+topics:
+  - infrastructure
 license: MIT
 version: 0.7.5.5
 contact:

--- a/packages/anndata-for-R/meta.yaml
+++ b/packages/anndata-for-R/meta.yaml
@@ -10,13 +10,12 @@ project_home: https://github.com/dynverse/anndata
 documentation_home: https://anndata.dynverse.org
 install:
   cran: anndata
+primary_category: Data structures
 tags:
   - data structures
   - interoperability
-  - R
-topics:
-  - infrastructure
 license: MIT
+language: R
 version: 0.7.5.5
 contact:
   - rcannood

--- a/packages/anndata/meta.yaml
+++ b/packages/anndata/meta.yaml
@@ -15,6 +15,8 @@ tags:
   - data structure
   - annotated data
   - sparse data
+topics:
+  - infrastructure
 license: BSD-3-Clause
 version: 0.12.4
 contact:

--- a/packages/anndata/meta.yaml
+++ b/packages/anndata/meta.yaml
@@ -15,6 +15,7 @@ primary_category: Data structures
 tags:
   - data structures
 license: BSD-3-Clause
+language: Python
 version: 0.12.4
 contact:
   - flying-sheep

--- a/packages/anndata/meta.yaml
+++ b/packages/anndata/meta.yaml
@@ -11,12 +11,9 @@ publications:
 install:
   pypi: anndata
   conda: conda-forge::anndata
+primary_category: Data structures
 tags:
-  - data structure
-  - annotated data
-  - sparse data
-topics:
-  - infrastructure
+  - data structures
 license: BSD-3-Clause
 version: 0.12.4
 contact:

--- a/packages/anndataR/meta.yaml
+++ b/packages/anndataR/meta.yaml
@@ -8,13 +8,11 @@ tutorials_home: https://scverse.org/anndataR/
 install:
   bioconductor: anndataR
 license: MIT
+language: R
+primary_category: Data structures
 tags:
   - data structures
   - interoperability
-  - R
-  - Bioconductor
-topics:
-  - infrastructure
 publications:
   - 10.1101/2025.08.18.669052 # bioRxiv preprint
 version: 1.0.0

--- a/packages/anndataR/meta.yaml
+++ b/packages/anndataR/meta.yaml
@@ -13,6 +13,8 @@ tags:
   - interoperability
   - R
   - Bioconductor
+topics:
+  - infrastructure
 publications:
   - 10.1101/2025.08.18.669052 # bioRxiv preprint
 version: 1.0.0

--- a/packages/annsel/meta.yaml
+++ b/packages/annsel/meta.yaml
@@ -8,6 +8,7 @@ tutorials_home: https://annsel.readthedocs.io/page/notebooks/all_of_annsel.html
 install:
   pypi: annsel
 license: MIT
+language: Python
 version: v0.0.8
 contact:
   - srivarra

--- a/packages/annsel/meta.yaml
+++ b/packages/annsel/meta.yaml
@@ -11,13 +11,9 @@ license: MIT
 version: v0.0.8
 contact:
   - srivarra
+primary_category: Data structures
 tags:
-  - narwhals
-  - dataframe
-  - accessor
-  - utilities
-topics:
-  - infrastructure
+  - data structures
 test_command: |
   pip install ".[test]" && pytest
 category: ecosystem

--- a/packages/annsel/meta.yaml
+++ b/packages/annsel/meta.yaml
@@ -16,6 +16,8 @@ tags:
   - dataframe
   - accessor
   - utilities
+topics:
+  - infrastructure
 test_command: |
   pip install ".[test]" && pytest
 category: ecosystem

--- a/packages/benGRN/meta.yaml
+++ b/packages/benGRN/meta.yaml
@@ -8,13 +8,11 @@ publications:
   - 10.1101/2024.07.29.605556
 install:
   pypi: bengrn
+primary_category: scRNA-seq
 tags:
-  - single cell
-  - RNAseq
-  - gene network inference
-  - benchmark
-topics:
-  - gene-networks
+  - scRNA-seq
+  - gene regulatory networks
+  - benchmarking
 license: MIT
 version: v1.2.1
 contact:

--- a/packages/benGRN/meta.yaml
+++ b/packages/benGRN/meta.yaml
@@ -13,6 +13,8 @@ tags:
   - RNAseq
   - gene network inference
   - benchmark
+topics:
+  - gene-networks
 license: MIT
 version: v1.2.1
 contact:

--- a/packages/benGRN/meta.yaml
+++ b/packages/benGRN/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - gene regulatory networks
   - benchmarking
 license: MIT
+language: Python
 version: v1.2.1
 contact:
   - jkobject

--- a/packages/bento-tools/meta.yaml
+++ b/packages/bento-tools/meta.yaml
@@ -10,6 +10,8 @@ install:
   pypi: bento-tools
 tags:
   - spatial analysis
+topics:
+  - spatial
 license: BSD-2-Clause
 version: v1.0.1
 contact:

--- a/packages/bento-tools/meta.yaml
+++ b/packages/bento-tools/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - spatial transcriptomics
   - segmentation
 license: BSD-2-Clause
+language: Python
 version: v1.0.1
 contact:
   - ckmah

--- a/packages/bento-tools/meta.yaml
+++ b/packages/bento-tools/meta.yaml
@@ -8,10 +8,10 @@ publications:
   - 10.1101/2022.06.10.495510
 install:
   pypi: bento-tools
+primary_category: Spatial
 tags:
-  - spatial analysis
-topics:
-  - spatial
+  - spatial transcriptomics
+  - segmentation
 license: BSD-2-Clause
 version: v1.0.1
 contact:

--- a/packages/biolord/meta.yaml
+++ b/packages/biolord/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - perturbation
   - deep learning
 license: BSD-3-Clause
+language: Python
 version: v0.0.1
 contact:
   - zoepiran

--- a/packages/biolord/meta.yaml
+++ b/packages/biolord/meta.yaml
@@ -10,6 +10,9 @@ tags:
   - single-cell
   - disentanglement
   - generative framework
+topics:
+  - perturbation
+  - integration
 license: BSD-3-Clause
 version: v0.0.1
 contact:

--- a/packages/biolord/meta.yaml
+++ b/packages/biolord/meta.yaml
@@ -6,13 +6,11 @@ documentation_home: https://biolord.readthedocs.io/
 tutorials_home: https://biolord.readthedocs.io/
 install:
   pypi: biolord
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - disentanglement
-  - generative framework
-topics:
+  - dimensionality reduction
   - perturbation
-  - integration
+  - deep learning
 license: BSD-3-Clause
 version: v0.0.1
 contact:

--- a/packages/cell2location/meta.yaml
+++ b/packages/cell2location/meta.yaml
@@ -11,11 +11,12 @@ publications:
   - 10.1038/s41587-021-01139-4
 install:
   pypi: cell2location
+primary_category: Spatial
 tags:
-  - Bayesian
-topics:
-  - spatial
+  - spatial transcriptomics
+  - cell-type annotation
   - deconvolution
+  - probabilistic modeling
 license: Apache-2.0
 version: v0.1
 contact:

--- a/packages/cell2location/meta.yaml
+++ b/packages/cell2location/meta.yaml
@@ -18,6 +18,7 @@ tags:
   - deconvolution
   - probabilistic modeling
 license: Apache-2.0
+language: Python
 version: v0.1
 contact:
   - vitkl

--- a/packages/cell2location/meta.yaml
+++ b/packages/cell2location/meta.yaml
@@ -13,6 +13,9 @@ install:
   pypi: cell2location
 tags:
   - Bayesian
+topics:
+  - spatial
+  - deconvolution
 license: Apache-2.0
 version: v0.1
 contact:

--- a/packages/cellxgene/meta.yaml
+++ b/packages/cellxgene/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - cell-type annotation
   - visualization
 license: MIT
+language: Python
 version: 1.1.1
 contact:
   - csweaver

--- a/packages/cellxgene/meta.yaml
+++ b/packages/cellxgene/meta.yaml
@@ -8,11 +8,10 @@ publications:
   - 10.1101/2021.04.05.438318
 install:
   pypi: cellxgene
+primary_category: scRNA-seq
 tags:
-  - HCA
-topics:
+  - cell-type annotation
   - visualization
-  - annotation
 license: MIT
 version: 1.1.1
 contact:

--- a/packages/cellxgene/meta.yaml
+++ b/packages/cellxgene/meta.yaml
@@ -10,6 +10,9 @@ install:
   pypi: cellxgene
 tags:
   - HCA
+topics:
+  - visualization
+  - annotation
 license: MIT
 version: 1.1.1
 contact:

--- a/packages/clone2vec/meta.yaml
+++ b/packages/clone2vec/meta.yaml
@@ -6,10 +6,9 @@ documentation_home: https://clone2vec.readthedocs.io/
 tutorials_home: https://clone2vec.readthedocs.io/
 install:
   pypi: clone2vec
+primary_category: scRNA-seq
 tags:
-  - label-transfer
-topics:
-  - trajectory
+  - lineage tracing
 license: MIT
 publications:
   - 10.1101/2024.11.15.623687

--- a/packages/clone2vec/meta.yaml
+++ b/packages/clone2vec/meta.yaml
@@ -8,6 +8,8 @@ install:
   pypi: clone2vec
 tags:
   - label-transfer
+topics:
+  - trajectory
 license: MIT
 publications:
   - 10.1101/2024.11.15.623687

--- a/packages/clone2vec/meta.yaml
+++ b/packages/clone2vec/meta.yaml
@@ -10,6 +10,7 @@ primary_category: scRNA-seq
 tags:
   - lineage tracing
 license: MIT
+language: Python
 publications:
   - 10.1101/2024.11.15.623687
 version: v0.1.0

--- a/packages/cookiecutter-scverse/meta.yaml
+++ b/packages/cookiecutter-scverse/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - documentation
 license: BSD-3-Clause
+language: Python
 version: 0.6.0
 contact:
   - grst

--- a/packages/cookiecutter-scverse/meta.yaml
+++ b/packages/cookiecutter-scverse/meta.yaml
@@ -3,11 +3,9 @@ description: |
   Cookiecutter template for scverse packages offering automated template sync
 project_home: https://github.com/scverse/cookiecutter-scverse
 documentation_home: https://cookiecutter-scverse-instance.readthedocs.io/page/template_usage.html
+primary_category: Infrastructure
 tags:
-  - template
-  - cookiecutter
-topics:
-  - infrastructure
+  - documentation
 license: BSD-3-Clause
 version: 0.6.0
 contact:

--- a/packages/cookiecutter-scverse/meta.yaml
+++ b/packages/cookiecutter-scverse/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://cookiecutter-scverse-instance.readthedocs.io/page/te
 tags:
   - template
   - cookiecutter
+topics:
+  - infrastructure
 license: BSD-3-Clause
 version: 0.6.0
 contact:

--- a/packages/dandelion/meta.yaml
+++ b/packages/dandelion/meta.yaml
@@ -16,6 +16,7 @@ primary_category: Adaptive immune cell receptor
 tags:
   - immune receptor
 license: AGPL-3.0-or-later
+language: Python
 version: v0.3.0
 contact:
   - zktuong

--- a/packages/dandelion/meta.yaml
+++ b/packages/dandelion/meta.yaml
@@ -16,6 +16,9 @@ tags:
   - dandelion
   - bcr
   - tcr
+topics:
+  - immune
+  - preprocessing
 license: AGPL-3.0-or-later
 version: v0.3.0
 contact:

--- a/packages/dandelion/meta.yaml
+++ b/packages/dandelion/meta.yaml
@@ -12,13 +12,9 @@ publications:
   - 10.1101/2022.11.18.517068
 install:
   pypi: sc-dandelion
+primary_category: Adaptive immune cell receptor
 tags:
-  - dandelion
-  - bcr
-  - tcr
-topics:
-  - immune
-  - preprocessing
+  - immune receptor
 license: AGPL-3.0-or-later
 version: v0.3.0
 contact:

--- a/packages/decoupler/meta.yaml
+++ b/packages/decoupler/meta.yaml
@@ -14,6 +14,7 @@ primary_category: scRNA-seq
 tags:
   - functional analysis
 license: BSD-3-Clause
+language: Python
 version: 2.1.1
 contact:
   - PauBadiaM

--- a/packages/decoupler/meta.yaml
+++ b/packages/decoupler/meta.yaml
@@ -15,6 +15,8 @@ tags:
   - pathway analysis
   - gene sets
   - functional annotation
+topics:
+  - differential-analysis
 license: BSD-3-Clause
 version: 2.1.1
 contact:

--- a/packages/decoupler/meta.yaml
+++ b/packages/decoupler/meta.yaml
@@ -10,13 +10,9 @@ publications:
 install:
   pypi: decoupler
   conda: conda-forge::decoupler-py
+primary_category: scRNA-seq
 tags:
-  - enrichment analysis
-  - pathway analysis
-  - gene sets
-  - functional annotation
-topics:
-  - differential-analysis
+  - functional analysis
 license: BSD-3-Clause
 version: 2.1.1
 contact:

--- a/packages/delnx/meta.yaml
+++ b/packages/delnx/meta.yaml
@@ -10,6 +10,7 @@ primary_category: scRNA-seq
 tags:
   - differential expression
 license: MIT
+language: Python
 version: v0.2.3
 contact:
   - joschif

--- a/packages/delnx/meta.yaml
+++ b/packages/delnx/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - regression models
   - dispersion estimation
   - JAX
+topics:
+  - differential-analysis
 license: MIT
 version: v0.2.3
 contact:

--- a/packages/delnx/meta.yaml
+++ b/packages/delnx/meta.yaml
@@ -6,13 +6,9 @@ documentation_home: https://delnx.readthedocs.io/
 tutorials_home: https://delnx.readthedocs.io/
 install:
   pypi: delnx
+primary_category: scRNA-seq
 tags:
   - differential expression
-  - regression models
-  - dispersion estimation
-  - JAX
-topics:
-  - differential-analysis
 license: MIT
 version: v0.2.3
 contact:

--- a/packages/dvp-io/meta.yaml
+++ b/packages/dvp-io/meta.yaml
@@ -10,6 +10,10 @@ tags:
   - LC/MS-proteomics
   - Spatial Proteomics
   - Reader
+topics:
+  - spatial
+  - proteomics
+  - infrastructure
 license: Apache-2.0
 version: 0.5.1
 contact:

--- a/packages/dvp-io/meta.yaml
+++ b/packages/dvp-io/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - proteomics
   - file formats
 license: Apache-2.0
+language: Python
 version: 0.5.1
 contact:
   - lucas-diedrich

--- a/packages/dvp-io/meta.yaml
+++ b/packages/dvp-io/meta.yaml
@@ -6,14 +6,11 @@ documentation_home: https://dvp-io.readthedocs.io
 tutorials_home: https://dvp-io.readthedocs.io/page/tutorials.html
 install:
   pypi: dvp-io
+primary_category: Spatial
 tags:
-  - LC/MS-proteomics
-  - Spatial Proteomics
-  - Reader
-topics:
-  - spatial
+  - spatial proteomics
   - proteomics
-  - infrastructure
+  - file formats
 license: Apache-2.0
 version: 0.5.1
 contact:

--- a/packages/dynamo-release/meta.yaml
+++ b/packages/dynamo-release/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - trajectory inference
   - RNA velocity
 license: BSD-3-Clause
+language: Python
 version: v1.1.0
 contact:
   - Xiaojieqiu

--- a/packages/dynamo-release/meta.yaml
+++ b/packages/dynamo-release/meta.yaml
@@ -10,11 +10,11 @@ publications:
   - 10.1016/j.cell.2021.12.045
 install:
   pypi: dynamo-release
+primary_category: Multimodal
 tags:
-  - vector
-topics:
-  - trajectory
-  - multi-omics
+  - multimodal
+  - trajectory inference
+  - RNA velocity
 license: BSD-3-Clause
 version: v1.1.0
 contact:

--- a/packages/dynamo-release/meta.yaml
+++ b/packages/dynamo-release/meta.yaml
@@ -12,6 +12,9 @@ install:
   pypi: dynamo-release
 tags:
   - vector
+topics:
+  - trajectory
+  - multi-omics
 license: BSD-3-Clause
 version: v1.1.0
 contact:

--- a/packages/ecosystem-packages/meta.yaml
+++ b/packages/ecosystem-packages/meta.yaml
@@ -3,11 +3,9 @@ description: |
   Registry for scverse ecosystem packages (https://scverse.org/packages/#ecosystem)
 project_home: https://github.com/scverse/ecosystem-packages
 documentation_home: https://github.com/scverse/ecosystem-packages
+primary_category: Infrastructure
 tags:
-  - registry
-  - ecosystem
-topics:
-  - infrastructure
+  - documentation
 license: BSD-3-Clause
 contact:
   - grst

--- a/packages/ecosystem-packages/meta.yaml
+++ b/packages/ecosystem-packages/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://github.com/scverse/ecosystem-packages
 tags:
   - registry
   - ecosystem
+topics:
+  - infrastructure
 license: BSD-3-Clause
 contact:
   - grst

--- a/packages/ecosystem-packages/meta.yaml
+++ b/packages/ecosystem-packages/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - documentation
 license: BSD-3-Clause
+language: Python
 contact:
   - grst
   - flying-sheep

--- a/packages/epiScanpy/meta.yaml
+++ b/packages/epiScanpy/meta.yaml
@@ -13,6 +13,7 @@ primary_category: Epigenomics
 tags:
   - epigenomics
 license: BSD-3-Clause
+language: Python
 version: v0.3.2
 contact:
   - DaneseAnna

--- a/packages/epiScanpy/meta.yaml
+++ b/packages/epiScanpy/meta.yaml
@@ -9,10 +9,8 @@ publications:
   - 10.1038/s41467-021-25131-3
 install:
   pypi: episcanpy
+primary_category: Epigenomics
 tags:
-  - scanpy
-  - epigenomics
-topics:
   - epigenomics
 license: BSD-3-Clause
 version: v0.3.2

--- a/packages/epiScanpy/meta.yaml
+++ b/packages/epiScanpy/meta.yaml
@@ -12,6 +12,8 @@ install:
 tags:
   - scanpy
   - epigenomics
+topics:
+  - epigenomics
 license: BSD-3-Clause
 version: v0.3.2
 contact:

--- a/packages/eschr/meta.yaml
+++ b/packages/eschr/meta.yaml
@@ -13,6 +13,8 @@ tags:
   - clustering
   - uncertainty
   - ensemble
+topics:
+  - clustering
 license: "MIT"
 version: v1.0.1
 contact:

--- a/packages/eschr/meta.yaml
+++ b/packages/eschr/meta.yaml
@@ -9,12 +9,10 @@ publications:
   - 10.1186/s13059-024-03386-5
 install:
   pypi: eschr
+primary_category: scRNA-seq
 tags:
   - clustering
-  - uncertainty
-  - ensemble
-topics:
-  - clustering
+  - probabilistic modeling
 license: "MIT"
 version: v1.0.1
 contact:

--- a/packages/eschr/meta.yaml
+++ b/packages/eschr/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - clustering
   - probabilistic modeling
 license: "MIT"
+language: Python
 version: v1.0.1
 contact:
   - smgoggin10

--- a/packages/favapy/meta.yaml
+++ b/packages/favapy/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - dimensionality reduction
   - deep learning
 license: MIT
+language: Python
 version: v0.3.9.4
 contact:
   - mikelkou

--- a/packages/favapy/meta.yaml
+++ b/packages/favapy/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - coexpression networks
   - functional associations
   - variational autoencoders
+topics:
+  - gene-networks
 license: MIT
 version: v0.3.9.4
 contact:

--- a/packages/favapy/meta.yaml
+++ b/packages/favapy/meta.yaml
@@ -10,12 +10,11 @@ publications:
   - 10.1093/nar/gkac1000
 install:
   pypi: favapy
+primary_category: scRNA-seq
 tags:
-  - coexpression networks
-  - functional associations
-  - variational autoencoders
-topics:
-  - gene-networks
+  - gene regulatory networks
+  - dimensionality reduction
+  - deep learning
 license: MIT
 version: v0.3.9.4
 contact:

--- a/packages/flashdeconv/meta.yaml
+++ b/packages/flashdeconv/meta.yaml
@@ -18,6 +18,7 @@ tags:
   - cell-type annotation
   - deconvolution
 license: BSD-3-Clause
+language: Python
 version: v0.1
 contact:
   - cafferychen777

--- a/packages/flashdeconv/meta.yaml
+++ b/packages/flashdeconv/meta.yaml
@@ -18,6 +18,9 @@ tags:
   - cell type
   - Visium HD
   - sketching
+topics:
+  - spatial
+  - deconvolution
 license: BSD-3-Clause
 version: v0.1
 contact:

--- a/packages/flashdeconv/meta.yaml
+++ b/packages/flashdeconv/meta.yaml
@@ -12,14 +12,10 @@ publications:
   - 10.64898/2025.12.22.696108
 install:
   pypi: flashdeconv
+primary_category: Spatial
 tags:
   - spatial transcriptomics
-  - deconvolution
-  - cell type
-  - Visium HD
-  - sketching
-topics:
-  - spatial
+  - cell-type annotation
   - deconvolution
 license: BSD-3-Clause
 version: v0.1

--- a/packages/flowsom/meta.yaml
+++ b/packages/flowsom/meta.yaml
@@ -17,6 +17,10 @@ install:
 tags:
   - clustering
   - flowcytometry
+topics:
+  - proteomics
+  - clustering
+  - visualization
 license: GPL-3.0-only
 version: v0.0.1
 contact:

--- a/packages/flowsom/meta.yaml
+++ b/packages/flowsom/meta.yaml
@@ -14,13 +14,10 @@ publications:
   - 10.1038/s41596-021-00550-0
 install:
   conda: conda-forge::flowsom
+primary_category: Proteomics
 tags:
+  - flow cytometry
   - clustering
-  - flowcytometry
-topics:
-  - proteomics
-  - clustering
-  - visualization
 license: GPL-3.0-only
 version: v0.0.1
 contact:

--- a/packages/flowsom/meta.yaml
+++ b/packages/flowsom/meta.yaml
@@ -19,6 +19,7 @@ tags:
   - flow cytometry
   - clustering
 license: GPL-3.0-only
+language: Python
 version: v0.0.1
 contact:
   - artuurC

--- a/packages/governance/meta.yaml
+++ b/packages/governance/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - documentation
 license: BSD-3-Clause
+language: Python
 contact:
   - Zethson
   - gtca

--- a/packages/governance/meta.yaml
+++ b/packages/governance/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://scverse.org/about
 tags:
   - governance
   - documentation
+topics:
+  - infrastructure
 license: BSD-3-Clause
 contact:
   - Zethson

--- a/packages/governance/meta.yaml
+++ b/packages/governance/meta.yaml
@@ -3,11 +3,9 @@ description: |
   Governance docs for scverse
 project_home: https://github.com/scverse/governance
 documentation_home: https://scverse.org/about
+primary_category: Infrastructure
 tags:
-  - governance
   - documentation
-topics:
-  - infrastructure
 license: BSD-3-Clause
 contact:
   - Zethson

--- a/packages/grassp/meta.yaml
+++ b/packages/grassp/meta.yaml
@@ -13,6 +13,9 @@ tags:
   - subcellular proteomics
   - mass-spectrometry
   - graph-based analysis
+topics:
+  - proteomics
+  - spatial
 license: BSD-3-Clause
 version: v0.1.0
 contact:

--- a/packages/grassp/meta.yaml
+++ b/packages/grassp/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - spatial proteomics
   - proteomics
 license: BSD-3-Clause
+language: Python
 version: v0.1.0
 contact:
   - mffrank

--- a/packages/grassp/meta.yaml
+++ b/packages/grassp/meta.yaml
@@ -9,13 +9,10 @@ documentation_home: https://public.czbiohub.org/comp.bio/grassp/
 tutorials_home: https://public.czbiohub.org/comp.bio/grassp/tutorials/
 install:
   pypi: grassp
+primary_category: Spatial
 tags:
-  - subcellular proteomics
-  - mass-spectrometry
-  - graph-based analysis
-topics:
+  - spatial proteomics
   - proteomics
-  - spatial
 license: BSD-3-Clause
 version: v0.1.0
 contact:

--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - geneset-scoring
   - smoothing
   - python
+topics:
+  - differential-analysis
 license: MIT
 version: v0.4.2
 contact:

--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -8,14 +8,11 @@ publications:
   - 10.1093/bioadv/vbad150
 install:
   pypi: gssnng
+primary_category: scRNA-seq
 tags:
   - scRNA-seq
-  - GSEA
-  - geneset-scoring
-  - smoothing
-  - python
-topics:
-  - differential-analysis
+  - preprocessing
+  - functional analysis
 license: MIT
 version: v0.4.2
 contact:

--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - preprocessing
   - functional analysis
 license: MIT
+language: Python
 version: v0.4.2
 contact:
   - gibbsdavidl

--- a/packages/hotspot/meta.yaml
+++ b/packages/hotspot/meta.yaml
@@ -8,10 +8,10 @@ publications:
   - 10.1016/j.cels.2021.04.005
 install:
   pypi: hotspotsc
+primary_category: scRNA-seq
 tags:
-  - gene-signatures
-topics:
-  - gene-networks
+  - functional analysis
+  - gene regulatory networks
 license: BSD-3-Clause
 version: v1.1.1
 contact:

--- a/packages/hotspot/meta.yaml
+++ b/packages/hotspot/meta.yaml
@@ -10,6 +10,8 @@ install:
   pypi: hotspotsc
 tags:
   - gene-signatures
+topics:
+  - gene-networks
 license: BSD-3-Clause
 version: v1.1.1
 contact:

--- a/packages/hotspot/meta.yaml
+++ b/packages/hotspot/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - functional analysis
   - gene regulatory networks
 license: BSD-3-Clause
+language: Python
 version: v1.1.1
 contact:
   - deto

--- a/packages/illico/meta.yaml
+++ b/packages/illico/meta.yaml
@@ -10,6 +10,8 @@ install:
 tags:
   - differential-gene-expression
   - single-cell-RNA-seq
+topics:
+  - differential-analysis
 license: Apache-2.0
 version: 0.1.1
 contact:

--- a/packages/illico/meta.yaml
+++ b/packages/illico/meta.yaml
@@ -7,11 +7,10 @@ tutorials_home: https://github.com/remydubois/illico
 publications: []
 install:
   pypi: illico
+primary_category: scRNA-seq
 tags:
-  - differential-gene-expression
-  - single-cell-RNA-seq
-topics:
-  - differential-analysis
+  - scRNA-seq
+  - differential expression
 license: Apache-2.0
 version: 0.1.1
 contact:

--- a/packages/illico/meta.yaml
+++ b/packages/illico/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - scRNA-seq
   - differential expression
 license: Apache-2.0
+language: Python
 version: 0.1.1
 contact:
   - remydubois

--- a/packages/infercnvpy/meta.yaml
+++ b/packages/infercnvpy/meta.yaml
@@ -6,10 +6,9 @@ documentation_home: https://infercnvpy.readthedocs.io/
 tutorials_home: https://infercnvpy.readthedocs.io/page/tutorials.html
 install:
   pypi: infercnvpy
+primary_category: scRNA-seq
 tags:
-  - CNV
-topics:
-  - annotation
+  - copy number variation
 license: BSD-3-Clause
 version: v0.3.0
 contact:

--- a/packages/infercnvpy/meta.yaml
+++ b/packages/infercnvpy/meta.yaml
@@ -8,6 +8,8 @@ install:
   pypi: infercnvpy
 tags:
   - CNV
+topics:
+  - annotation
 license: BSD-3-Clause
 version: v0.3.0
 contact:

--- a/packages/infercnvpy/meta.yaml
+++ b/packages/infercnvpy/meta.yaml
@@ -10,6 +10,7 @@ primary_category: scRNA-seq
 tags:
   - copy number variation
 license: BSD-3-Clause
+language: Python
 version: v0.3.0
 contact:
   - grst

--- a/packages/integration-testing/meta.yaml
+++ b/packages/integration-testing/meta.yaml
@@ -3,11 +3,9 @@ description: |
   A repo for integration testing core packages against upstream core packages
 project_home: https://github.com/scverse/integration-testing
 documentation_home: https://github.com/scverse/integration-testing
+primary_category: Infrastructure
 tags:
-  - testing
-  - continuous integration
-topics:
-  - infrastructure
+  - benchmarking
 license: MIT
 contact:
   - ilan-gold

--- a/packages/integration-testing/meta.yaml
+++ b/packages/integration-testing/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://github.com/scverse/integration-testing
 tags:
   - testing
   - continuous integration
+topics:
+  - infrastructure
 license: MIT
 contact:
   - ilan-gold

--- a/packages/integration-testing/meta.yaml
+++ b/packages/integration-testing/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - benchmarking
 license: MIT
+language: Python
 contact:
   - ilan-gold
   - flying-sheep

--- a/packages/kompot/meta.yaml
+++ b/packages/kompot/meta.yaml
@@ -14,17 +14,11 @@ publications:
 install:
   pypi: kompot
   conda: bioconda::kompot
+primary_category: scRNA-seq
 tags:
-  - differential-expression
-  - differential-abundance
-  - mahalanobis-distance
-  - gaussian-process
-  - phenotypic manifold
-  - continuous representation
-  - jax
-  - anndata
-topics:
-  - differential-analysis
+  - differential expression
+  - compositional analysis
+  - probabilistic modeling
 license: GPL-3.0-or-later
 version: v0.6.1
 contact:

--- a/packages/kompot/meta.yaml
+++ b/packages/kompot/meta.yaml
@@ -20,6 +20,7 @@ tags:
   - compositional analysis
   - probabilistic modeling
 license: GPL-3.0-or-later
+language: Python
 version: v0.6.1
 contact:
   - katosh

--- a/packages/kompot/meta.yaml
+++ b/packages/kompot/meta.yaml
@@ -23,6 +23,8 @@ tags:
   - continuous representation
   - jax
   - anndata
+topics:
+  - differential-analysis
 license: GPL-3.0-or-later
 version: v0.6.1
 contact:

--- a/packages/liana/meta.yaml
+++ b/packages/liana/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - spatial transcriptomics
   - cell-cell communication
 license: GPL-3.0-only
+language: Python
 version: v1.0.0a1
 contact:
   - dbdimitrov

--- a/packages/liana/meta.yaml
+++ b/packages/liana/meta.yaml
@@ -11,6 +11,9 @@ tags:
   - spatial
   - ligand-receptor
   - cell-cell communication
+topics:
+  - cell-communication
+  - spatial
 license: GPL-3.0-only
 version: v1.0.0a1
 contact:

--- a/packages/liana/meta.yaml
+++ b/packages/liana/meta.yaml
@@ -6,14 +6,10 @@ documentation_home: https://liana-py.readthedocs.io/
 tutorials_home: https://liana-py.readthedocs.io/
 install:
   pypi: liana
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - spatial
-  - ligand-receptor
+  - spatial transcriptomics
   - cell-cell communication
-topics:
-  - cell-communication
-  - spatial
 license: GPL-3.0-only
 version: v1.0.0a1
 contact:

--- a/packages/maxspin/meta.yaml
+++ b/packages/maxspin/meta.yaml
@@ -11,6 +11,9 @@ install:
 tags:
   - spatially varying genes
   - spatial autocorrelation
+topics:
+  - spatial
+  - differential-analysis
 license: MIT
 version: v0.1.1
 contact:

--- a/packages/maxspin/meta.yaml
+++ b/packages/maxspin/meta.yaml
@@ -8,12 +8,9 @@ documentation_home: https://maxspin.readthedocs.io/
 tutorials_home: https://github.com/dcjones/maxspin/blob/main/tutorial.ipynb
 install:
   pypi: maxspin
+primary_category: Spatial
 tags:
-  - spatially varying genes
-  - spatial autocorrelation
-topics:
-  - spatial
-  - differential-analysis
+  - spatially variable genes
 license: MIT
 version: v0.1.1
 contact:

--- a/packages/maxspin/meta.yaml
+++ b/packages/maxspin/meta.yaml
@@ -12,6 +12,7 @@ primary_category: Spatial
 tags:
   - spatially variable genes
 license: MIT
+language: Python
 version: v0.1.1
 contact:
   - dcjones

--- a/packages/moscot/meta.yaml
+++ b/packages/moscot/meta.yaml
@@ -7,15 +7,12 @@ publications:
   - 10.1101/2023.05.11.540374
 install:
   pypi: moscot
+primary_category: Multimodal
 tags:
-  - optimal transport
+  - spatial transcriptomics
+  - multimodal
   - trajectory inference
-  - multi omics
-  - spatial
-topics:
-  - multi-omics
-  - trajectory
-  - spatial
+  - optimal transport
 license: BSD-3-Clause
 version: v0.4.0
 contact:

--- a/packages/moscot/meta.yaml
+++ b/packages/moscot/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - trajectory inference
   - optimal transport
 license: BSD-3-Clause
+language: Python
 version: v0.4.0
 contact:
   - MUCDK

--- a/packages/moscot/meta.yaml
+++ b/packages/moscot/meta.yaml
@@ -12,6 +12,10 @@ tags:
   - trajectory inference
   - multi omics
   - spatial
+topics:
+  - multi-omics
+  - trajectory
+  - spatial
 license: BSD-3-Clause
 version: v0.4.0
 contact:

--- a/packages/mudata/meta.yaml
+++ b/packages/mudata/meta.yaml
@@ -15,6 +15,9 @@ tags:
   - data structure
   - multimodal
   - multi-omics
+topics:
+  - multi-omics
+  - infrastructure
 license: BSD-3-Clause
 version: 0.3.2
 contact:

--- a/packages/mudata/meta.yaml
+++ b/packages/mudata/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - multimodal
   - data structures
 license: BSD-3-Clause
+language: Python
 version: 0.3.2
 contact:
   - gtca

--- a/packages/mudata/meta.yaml
+++ b/packages/mudata/meta.yaml
@@ -11,13 +11,10 @@ publications:
 install:
   pypi: mudata
   conda: conda-forge::mudata
+primary_category: Data structures
 tags:
-  - data structure
   - multimodal
-  - multi-omics
-topics:
-  - multi-omics
-  - infrastructure
+  - data structures
 license: BSD-3-Clause
 version: 0.3.2
 contact:

--- a/packages/muon/meta.yaml
+++ b/packages/muon/meta.yaml
@@ -10,14 +10,10 @@ publications:
 install:
   pypi: muon
   conda: conda-forge::muon
+primary_category: Multimodal
 tags:
   - multimodal
-  - multi-omics
-  - integration
-topics:
-  - multi-omics
-  - integration
-  - preprocessing
+  - data integration
 license: BSD-3-Clause
 version: 0.1.7
 contact:

--- a/packages/muon/meta.yaml
+++ b/packages/muon/meta.yaml
@@ -14,6 +14,10 @@ tags:
   - multimodal
   - multi-omics
   - integration
+topics:
+  - multi-omics
+  - integration
+  - preprocessing
 license: BSD-3-Clause
 version: 0.1.7
 contact:

--- a/packages/muon/meta.yaml
+++ b/packages/muon/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - multimodal
   - data integration
 license: BSD-3-Clause
+language: Python
 version: 0.1.7
 contact:
   - gtca

--- a/packages/nichepca/meta.yaml
+++ b/packages/nichepca/meta.yaml
@@ -10,6 +10,9 @@ tags:
   - spatial-omics
   - spatial domain identification
   - spatial clustering
+topics:
+  - spatial
+  - clustering
 license: MIT
 version: v0.0.3
 contact:

--- a/packages/nichepca/meta.yaml
+++ b/packages/nichepca/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - spatial transcriptomics
   - clustering
 license: MIT
+language: Python
 version: v0.0.3
 contact:
   - dschaub95

--- a/packages/nichepca/meta.yaml
+++ b/packages/nichepca/meta.yaml
@@ -6,12 +6,9 @@ documentation_home: https://nichepca.readthedocs.io/
 tutorials_home: https://nichepca.readthedocs.io/page/notebooks/example.html
 install:
   pypi: nichepca
+primary_category: Spatial
 tags:
-  - spatial-omics
-  - spatial domain identification
-  - spatial clustering
-topics:
-  - spatial
+  - spatial transcriptomics
   - clustering
 license: MIT
 version: v0.0.3

--- a/packages/novae/meta.yaml
+++ b/packages/novae/meta.yaml
@@ -13,6 +13,10 @@ tags:
   - spatial-transcriptomics
   - spatialdata
   - deep learning
+topics:
+  - spatial
+  - clustering
+  - integration
 license: BSD-3-Clause
 version: v0.2.1
 contact:

--- a/packages/novae/meta.yaml
+++ b/packages/novae/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - spatial transcriptomics
   - deep learning
 license: BSD-3-Clause
+language: Python
 version: v0.2.1
 contact:
   - quentinblampey

--- a/packages/novae/meta.yaml
+++ b/packages/novae/meta.yaml
@@ -8,15 +8,10 @@ publications:
   - 10.1101/2024.09.09.612009
 install:
   pypi: novae
+primary_category: Spatial
 tags:
-  - spatial-omics
-  - spatial-transcriptomics
-  - spatialdata
+  - spatial transcriptomics
   - deep learning
-topics:
-  - spatial
-  - clustering
-  - integration
 license: BSD-3-Clause
 version: v0.2.1
 contact:

--- a/packages/omicverse/meta.yaml
+++ b/packages/omicverse/meta.yaml
@@ -9,13 +9,10 @@ publications:
   - 10.1101/2023.06.06.543913
 install:
   pypi: omicverse
+primary_category: Multimodal
 tags:
-  - single-cell
-  - bulk-rna-seq
-  - omics
-  - bioinformatics
-topics:
-  - multi-omics
+  - bulk RNA-seq
+  - multimodal
 license: GPL-3.0-only
 version: v1.4.12
 contact:

--- a/packages/omicverse/meta.yaml
+++ b/packages/omicverse/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - bulk RNA-seq
   - multimodal
 license: GPL-3.0-only
+language: Python
 version: v1.4.12
 contact:
   - Starlitnightly

--- a/packages/omicverse/meta.yaml
+++ b/packages/omicverse/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - bulk-rna-seq
   - omics
   - bioinformatics
+topics:
+  - multi-omics
 license: GPL-3.0-only
 version: v1.4.12
 contact:

--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -19,6 +19,7 @@ tags:
   - dimensionality reduction
   - trajectory inference
 license: GPL-2.0-or-later
+language: Python
 version: v1.3.3
 contact:
   - ManuSetty

--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -24,6 +24,8 @@ tags:
   - single-cell-genomics
   - cell-fate-transitions
   - scrna-seq-analysis
+topics:
+  - trajectory
 license: GPL-2.0-or-later
 version: v1.3.3
 contact:

--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -13,19 +13,11 @@ publications:
   - 10.1038/s41587-019-0068-4
 install:
   pypi: palantir
+primary_category: scRNA-seq
 tags:
-  - markov-chain
-  - dimensionality-reduction
-  - scrna-seq
-  - trajectory-generation
-  - diffusion-maps
-  - differentiation
-  - manifold-learning
-  - single-cell-genomics
-  - cell-fate-transitions
-  - scrna-seq-analysis
-topics:
-  - trajectory
+  - scRNA-seq
+  - dimensionality reduction
+  - trajectory inference
 license: GPL-2.0-or-later
 version: v1.3.3
 contact:

--- a/packages/panpipes/meta.yaml
+++ b/packages/panpipes/meta.yaml
@@ -14,6 +14,9 @@ tags:
   - pipeline
   - spatial
   - bioinformatics
+topics:
+  - multi-omics
+  - spatial
 license: BSD-3-Clause
 version: v0.5.0
 contact:

--- a/packages/panpipes/meta.yaml
+++ b/packages/panpipes/meta.yaml
@@ -14,6 +14,7 @@ tags:
   - multimodal
   - pipeline
 license: BSD-3-Clause
+language: Python
 version: v0.5.0
 contact:
   - bio-la

--- a/packages/panpipes/meta.yaml
+++ b/packages/panpipes/meta.yaml
@@ -8,15 +8,11 @@ publications:
   - 10.1101/2023.03.11.532085
 install:
   pypi: panpipes
+primary_category: Multimodal
 tags:
-  - single-cell
-  - multiomics
+  - spatial transcriptomics
+  - multimodal
   - pipeline
-  - spatial
-  - bioinformatics
-topics:
-  - multi-omics
-  - spatial
 license: BSD-3-Clause
 version: v0.5.0
 contact:

--- a/packages/pcdl/meta.yaml
+++ b/packages/pcdl/meta.yaml
@@ -6,16 +6,9 @@ tutorials_home: https://github.com/elmbeech/physicelldataloader/blob/master/man/
 install:
   pypi: pcdl
 license: BSD-3-Clause
+primary_category: Infrastructure
 tags:
-  - python3
-  - downstream data analysis
-  - physicell
-  - multicellular system
-  - agent-based modeling
-  - diffusion transport solver
-  - newtonian physics
-topics:
-  - infrastructure
+  - file formats
 #publications:
 version: v4.0.4
 category: ecosystem

--- a/packages/pcdl/meta.yaml
+++ b/packages/pcdl/meta.yaml
@@ -6,6 +6,7 @@ tutorials_home: https://github.com/elmbeech/physicelldataloader/blob/master/man/
 install:
   pypi: pcdl
 license: BSD-3-Clause
+language: Python
 primary_category: Infrastructure
 tags:
   - file formats

--- a/packages/pcdl/meta.yaml
+++ b/packages/pcdl/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - agent-based modeling
   - diffusion transport solver
   - newtonian physics
+topics:
+  - infrastructure
 #publications:
 version: v4.0.4
 category: ecosystem

--- a/packages/pegasus/meta.yaml
+++ b/packages/pegasus/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - cell-type annotation
   - clustering
 license: BSD-3-Clause
+language: Python
 version: v1.7.1
 contact:
   - yihming

--- a/packages/pegasus/meta.yaml
+++ b/packages/pegasus/meta.yaml
@@ -10,6 +10,10 @@ install:
   pypi: pegasuspy
 tags:
   - transcriptome analysis
+topics:
+  - preprocessing
+  - clustering
+  - annotation
 license: BSD-3-Clause
 version: v1.7.1
 contact:

--- a/packages/pegasus/meta.yaml
+++ b/packages/pegasus/meta.yaml
@@ -8,12 +8,12 @@ publications:
   - 10.1038/s41592-020-0905-x
 install:
   pypi: pegasuspy
+primary_category: scRNA-seq
 tags:
-  - transcriptome analysis
-topics:
+  - scRNA-seq
   - preprocessing
+  - cell-type annotation
   - clustering
-  - annotation
 license: BSD-3-Clause
 version: v1.7.1
 contact:

--- a/packages/pertpy/meta.yaml
+++ b/packages/pertpy/meta.yaml
@@ -16,6 +16,9 @@ tags:
   - drug response
   - CRISPR
   - genetic perturbation
+topics:
+  - perturbation
+  - differential-analysis
 license: MIT
 version: 1.0.3
 contact:

--- a/packages/pertpy/meta.yaml
+++ b/packages/pertpy/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - differential expression
   - perturbation
 license: MIT
+language: Python
 version: 1.0.3
 contact:
   - Zethson

--- a/packages/pertpy/meta.yaml
+++ b/packages/pertpy/meta.yaml
@@ -11,14 +11,10 @@ publications:
 install:
   pypi: pertpy
   conda: conda-forge::pertpy
+primary_category: scRNA-seq
 tags:
+  - differential expression
   - perturbation
-  - drug response
-  - CRISPR
-  - genetic perturbation
-topics:
-  - perturbation
-  - differential-analysis
 license: MIT
 version: 1.0.3
 contact:

--- a/packages/popV/meta.yaml
+++ b/packages/popV/meta.yaml
@@ -9,6 +9,9 @@ tags:
   - cell type labels
   - batch integration
   - automatic annotation
+topics:
+  - annotation
+  - integration
 license: MIT
 version: v0.5.2
 contact:

--- a/packages/popV/meta.yaml
+++ b/packages/popV/meta.yaml
@@ -10,6 +10,7 @@ tags:
   - data integration
   - cell-type annotation
 license: MIT
+language: Python
 version: v0.5.2
 contact:
   - canergen

--- a/packages/popV/meta.yaml
+++ b/packages/popV/meta.yaml
@@ -5,13 +5,10 @@ project_home: https://github.com/YosefLab/popV
 documentation_home: https://popv.readthedocs.io/
 install:
   pypi: popv
+primary_category: scRNA-seq
 tags:
-  - cell type labels
-  - batch integration
-  - automatic annotation
-topics:
-  - annotation
-  - integration
+  - data integration
+  - cell-type annotation
 license: MIT
 version: v0.5.2
 contact:

--- a/packages/pyCrossTalkeR/meta.yaml
+++ b/packages/pyCrossTalkeR/meta.yaml
@@ -10,6 +10,9 @@ tags:
   - CCI
   - scRNAseq
   - Node Importance
+topics:
+  - cell-communication
+  - visualization
 license: MIT
 version: v2.1.0
 contact:

--- a/packages/pyCrossTalkeR/meta.yaml
+++ b/packages/pyCrossTalkeR/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - scRNA-seq
   - cell-cell communication
 license: MIT
+language: Python
 version: v2.1.0
 contact:
   - jsnagai

--- a/packages/pyCrossTalkeR/meta.yaml
+++ b/packages/pyCrossTalkeR/meta.yaml
@@ -6,13 +6,10 @@ documentation_home: https://pycrosstalker.readthedocs.io
 tutorials_home: https://pycrosstalker.readthedocs.io
 install:
   pypi: pycrosstalker
+primary_category: scRNA-seq
 tags:
-  - CCI
-  - scRNAseq
-  - Node Importance
-topics:
-  - cell-communication
-  - visualization
+  - scRNA-seq
+  - cell-cell communication
 license: MIT
 version: v2.1.0
 contact:

--- a/packages/pyLemur/meta.yaml
+++ b/packages/pyLemur/meta.yaml
@@ -8,12 +8,9 @@ publications:
   - 10.1101/2023.03.06.531268
 install:
   pypi: pyLemur
+primary_category: scRNA-seq
 tags:
-  - single-cell
   - differential expression
-  - multi-condition
-topics:
-  - differential-analysis
 license: MIT
 version: v0.1.0
 contact:

--- a/packages/pyLemur/meta.yaml
+++ b/packages/pyLemur/meta.yaml
@@ -12,6 +12,8 @@ tags:
   - single-cell
   - differential expression
   - multi-condition
+topics:
+  - differential-analysis
 license: MIT
 version: v0.1.0
 contact:

--- a/packages/pyLemur/meta.yaml
+++ b/packages/pyLemur/meta.yaml
@@ -12,6 +12,7 @@ primary_category: scRNA-seq
 tags:
   - differential expression
 license: MIT
+language: Python
 version: v0.1.0
 contact:
   - const-ae

--- a/packages/pySCENIC/meta.yaml
+++ b/packages/pySCENIC/meta.yaml
@@ -13,11 +13,9 @@ publications:
   - 10.1038/s41596-020-0336-2
 install:
   pypi: pyscenic
+primary_category: scRNA-seq
 tags:
-  - regulatory networks
-  - clustering
-topics:
-  - gene-networks
+  - gene regulatory networks
   - clustering
 license: GPL-3.0-only
 version: v0.12.0

--- a/packages/pySCENIC/meta.yaml
+++ b/packages/pySCENIC/meta.yaml
@@ -18,6 +18,7 @@ tags:
   - gene regulatory networks
   - clustering
 license: GPL-3.0-only
+language: Python
 version: v0.12.0
 contact:
   - bramvds

--- a/packages/pySCENIC/meta.yaml
+++ b/packages/pySCENIC/meta.yaml
@@ -16,6 +16,9 @@ install:
 tags:
   - regulatory networks
   - clustering
+topics:
+  - gene-networks
+  - clustering
 license: GPL-3.0-only
 version: v0.12.0
 contact:

--- a/packages/pyUCell/meta.yaml
+++ b/packages/pyUCell/meta.yaml
@@ -17,6 +17,7 @@ primary_category: scRNA-seq
 tags:
   - functional analysis
 license: MIT
+language: Python
 version: v0.3.0
 contact:
   - mass-a

--- a/packages/pyUCell/meta.yaml
+++ b/packages/pyUCell/meta.yaml
@@ -13,12 +13,9 @@ publications:
   - 10.1016/j.csbj.2021.06.043
 install:
   pypi: pyucell
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - signature scoring
-  - module scoring
-topics:
-  - differential-analysis
+  - functional analysis
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/pyUCell/meta.yaml
+++ b/packages/pyUCell/meta.yaml
@@ -17,6 +17,8 @@ tags:
   - single-cell
   - signature scoring
   - module scoring
+topics:
+  - differential-analysis
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/pycea/meta.yaml
+++ b/packages/pycea/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - lineage tracing
   - data structures
 license: BSD-3-Clause
+language: Python
 version: v0.1.0
 contact:
   - colganwi

--- a/packages/pycea/meta.yaml
+++ b/packages/pycea/meta.yaml
@@ -6,12 +6,10 @@ documentation_home: https://pycea.readthedocs.io/
 tutorials_home: https://pycea.readthedocs.io/
 install:
   pypi: pycea-lineage
+primary_category: scRNA-seq
 tags:
-  - lineage-tracing
-  - TreeData
-topics:
-  - trajectory
-  - visualization
+  - lineage tracing
+  - data structures
 license: BSD-3-Clause
 version: v0.1.0
 contact:

--- a/packages/pycea/meta.yaml
+++ b/packages/pycea/meta.yaml
@@ -9,6 +9,9 @@ install:
 tags:
   - lineage-tracing
   - TreeData
+topics:
+  - trajectory
+  - visualization
 license: BSD-3-Clause
 version: v0.1.0
 contact:

--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -9,6 +9,8 @@ install:
 tags:
   - TF
   - scATAC-seq
+topics:
+  - epigenomics
 license: MIT
 version: v0.0.3
 contact:

--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -6,11 +6,10 @@ documentation_home: https://pychromvar.readthedocs.io/
 tutorials_home: https://pychromvar.readthedocs.io/
 install:
   pypi: pychromvar
+primary_category: Epigenomics
 tags:
-  - TF
-  - scATAC-seq
-topics:
-  - epigenomics
+  - ATAC-seq
+  - gene regulatory networks
 license: MIT
 version: v0.0.3
 contact:

--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - ATAC-seq
   - gene regulatory networks
 license: MIT
+language: Python
 version: v0.0.3
 contact:
   - lzj1769

--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - differential expression
   - file formats
 license: GPL-3.0-only
+language: Python
 version: v0.2.0
 contact:
   - maltekuehl

--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -10,6 +10,8 @@ tags:
   - rna-seq
   - bulk-rna-seq
   - differential-expression
+topics:
+  - infrastructure
 license: GPL-3.0-only
 version: v0.2.0
 contact:

--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -6,12 +6,11 @@ documentation_home: https://pytximport.readthedocs.io/
 tutorials_home: https://pytximport.readthedocs.io/
 install:
   pypi: pytximport
+primary_category: bulk RNA-seq
 tags:
-  - rna-seq
-  - bulk-rna-seq
-  - differential-expression
-topics:
-  - infrastructure
+  - bulk RNA-seq
+  - differential expression
+  - file formats
 license: GPL-3.0-only
 version: v0.2.0
 contact:

--- a/packages/rapids-singlecell/meta.yaml
+++ b/packages/rapids-singlecell/meta.yaml
@@ -12,6 +12,9 @@ tags:
   - single-cell
   - RAPIDS
   - CUDA
+topics:
+  - preprocessing
+  - clustering
 license: MIT
 version: 0.13.3
 contact:

--- a/packages/rapids-singlecell/meta.yaml
+++ b/packages/rapids-singlecell/meta.yaml
@@ -7,14 +7,11 @@ documentation_home: https://rapids-singlecell.readthedocs.io/
 tutorials_home: https://rapids-singlecell.readthedocs.io/page/tutorials.html
 install:
   pypi: rapids-singlecell
+primary_category: scRNA-seq
 tags:
-  - GPU acceleration
-  - single-cell
-  - RAPIDS
-  - CUDA
-topics:
   - preprocessing
   - clustering
+  - GPU acceleration
 license: MIT
 version: 0.13.3
 contact:

--- a/packages/rapids-singlecell/meta.yaml
+++ b/packages/rapids-singlecell/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - clustering
   - GPU acceleration
 license: MIT
+language: Python
 version: 0.13.3
 contact:
   - Intron7

--- a/packages/scCellFie/meta.yaml
+++ b/packages/scCellFie/meta.yaml
@@ -12,6 +12,10 @@ tags:
   - metabolism
   - metabolic activities
   - cell-cell communication
+topics:
+  - differential-analysis
+  - spatial
+  - cell-communication
 license: MIT
 version: v0.4.5
 contact:

--- a/packages/scCellFie/meta.yaml
+++ b/packages/scCellFie/meta.yaml
@@ -6,16 +6,11 @@ documentation_home: https://sccellfie.readthedocs.io/
 tutorials_home: https://sccellfie.readthedocs.io/
 install:
   pypi: sccellfie
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - spatial
-  - metabolism
-  - metabolic activities
+  - spatial transcriptomics
+  - functional analysis
   - cell-cell communication
-topics:
-  - differential-analysis
-  - spatial
-  - cell-communication
 license: MIT
 version: v0.4.5
 contact:

--- a/packages/scCellFie/meta.yaml
+++ b/packages/scCellFie/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - functional analysis
   - cell-cell communication
 license: MIT
+language: Python
 version: v0.4.5
 contact:
   - earmingol

--- a/packages/scDataLoader/meta.yaml
+++ b/packages/scDataLoader/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - deep learning
   - file formats
 license: MIT
+language: Python
 version: v1.2.2
 contact:
   - jkobject

--- a/packages/scDataLoader/meta.yaml
+++ b/packages/scDataLoader/meta.yaml
@@ -17,6 +17,9 @@ tags:
   - lightning
   - cellxgene
   - preprocessing
+topics:
+  - infrastructure
+  - preprocessing
 license: MIT
 version: v1.2.2
 contact:

--- a/packages/scDataLoader/meta.yaml
+++ b/packages/scDataLoader/meta.yaml
@@ -9,17 +9,12 @@ publications:
   - 10.1101/2024.07.29.605556
 install:
   pypi: scdataloader
+primary_category: Infrastructure
 tags:
-  - dataloader
-  - single cell
-  - RNAseq
-  - pytorch
-  - lightning
-  - cellxgene
+  - scRNA-seq
   - preprocessing
-topics:
-  - infrastructure
-  - preprocessing
+  - deep learning
+  - file formats
 license: MIT
 version: v1.2.2
 contact:

--- a/packages/scFates/meta.yaml
+++ b/packages/scFates/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - trajectory inference
   - pseudotime
 license: BSD-3-Clause
+language: Python
 version: v1.0.0
 contact:
   - LouisFaure

--- a/packages/scFates/meta.yaml
+++ b/packages/scFates/meta.yaml
@@ -12,6 +12,8 @@ tags:
   - pseudotime
   - cell-fate
   - trajectory-generation
+topics:
+  - trajectory
 license: BSD-3-Clause
 version: v1.0.0
 contact:

--- a/packages/scFates/meta.yaml
+++ b/packages/scFates/meta.yaml
@@ -8,12 +8,10 @@ publications:
   - 10.1093/bioinformatics/btac746
 install:
   pypi: scFates
+primary_category: scRNA-seq
 tags:
+  - trajectory inference
   - pseudotime
-  - cell-fate
-  - trajectory-generation
-topics:
-  - trajectory
 license: BSD-3-Clause
 version: v1.0.0
 contact:

--- a/packages/scGen/meta.yaml
+++ b/packages/scGen/meta.yaml
@@ -13,6 +13,7 @@ primary_category: scRNA-seq
 tags:
   - perturbation
 license: GPL-3.0-only
+language: Python
 version: v2.1.0
 contact:
   - M0hammadL

--- a/packages/scGen/meta.yaml
+++ b/packages/scGen/meta.yaml
@@ -11,6 +11,8 @@ install:
   pypi: scgen
 tags:
   - perturbation
+topics:
+  - perturbation
 license: GPL-3.0-only
 version: v2.1.0
 contact:

--- a/packages/scGen/meta.yaml
+++ b/packages/scGen/meta.yaml
@@ -9,9 +9,8 @@ publications:
   - 10.1038/s41592-019-0494-8
 install:
   pypi: scgen
+primary_category: scRNA-seq
 tags:
-  - perturbation
-topics:
   - perturbation
 license: GPL-3.0-only
 version: v2.1.0

--- a/packages/scPRINT-2/meta.yaml
+++ b/packages/scPRINT-2/meta.yaml
@@ -19,6 +19,7 @@ tags:
   - deep learning
   - foundation model
 license: GPL-3.0-or-later
+language: Python
 version: v1.0.0
 contact:
   - jkobject

--- a/packages/scPRINT-2/meta.yaml
+++ b/packages/scPRINT-2/meta.yaml
@@ -22,6 +22,10 @@ tags:
   - species integration
   - expression imputation
   - counterfactual predictions
+topics:
+  - gene-networks
+  - annotation
+  - preprocessing
 license: GPL-3.0-or-later
 version: v1.0.0
 contact:

--- a/packages/scPRINT-2/meta.yaml
+++ b/packages/scPRINT-2/meta.yaml
@@ -7,25 +7,17 @@ publications:
   - 10.64898/2025.12.11.693702v2
 install:
   pypi: scprint2
+primary_category: scRNA-seq
 tags:
-  - foundation model
-  - single cell
-  - RNAseq
-  - gene network inference
+  - scRNA-seq
   - denoising
-  - zero imputation
-  - label prediction
-  - zero shot
-  - embedding
-  - pytorch
-  - lightning
-  - species integration
-  - expression imputation
-  - counterfactual predictions
-topics:
-  - gene-networks
-  - annotation
-  - preprocessing
+  - data integration
+  - cell-type annotation
+  - gene regulatory networks
+  - dimensionality reduction
+  - perturbation
+  - deep learning
+  - foundation model
 license: GPL-3.0-or-later
 version: v1.0.0
 contact:

--- a/packages/scPRINT/meta.yaml
+++ b/packages/scPRINT/meta.yaml
@@ -7,22 +7,15 @@ publications:
   - 10.1101/2024.07.29.605556
 install:
   pypi: scprint
+primary_category: scRNA-seq
 tags:
-  - foundation model
-  - single cell
-  - RNAseq
-  - gene network inference
+  - scRNA-seq
   - denoising
-  - zero imputation
-  - label prediction
-  - zero shot
-  - embedding
-  - pytorch
-  - lightning
-topics:
-  - gene-networks
-  - annotation
-  - preprocessing
+  - cell-type annotation
+  - gene regulatory networks
+  - dimensionality reduction
+  - deep learning
+  - foundation model
 license: MIT
 version: v1.6.2
 contact:

--- a/packages/scPRINT/meta.yaml
+++ b/packages/scPRINT/meta.yaml
@@ -17,6 +17,7 @@ tags:
   - deep learning
   - foundation model
 license: MIT
+language: Python
 version: v1.6.2
 contact:
   - jkobject

--- a/packages/scPRINT/meta.yaml
+++ b/packages/scPRINT/meta.yaml
@@ -19,6 +19,10 @@ tags:
   - embedding
   - pytorch
   - lightning
+topics:
+  - gene-networks
+  - annotation
+  - preprocessing
 license: MIT
 version: v1.6.2
 contact:

--- a/packages/scXpand/meta.yaml
+++ b/packages/scXpand/meta.yaml
@@ -15,6 +15,8 @@ tags:
   - scTCR-seq
   - T-cell clonal expansion
   - machine learning
+topics:
+  - immune
 license: MIT
 version: v0.4.3
 contact:

--- a/packages/scXpand/meta.yaml
+++ b/packages/scXpand/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - immune receptor
   - deep learning
 license: MIT
+language: Python
 version: v0.4.3
 contact:
   - ronamit

--- a/packages/scXpand/meta.yaml
+++ b/packages/scXpand/meta.yaml
@@ -9,14 +9,11 @@ publications:
   - 10.1101/2025.09.14.676069
 install:
   pypi: scxpand
+primary_category: Adaptive immune cell receptor
 tags:
-  - cancer
   - scRNA-seq
-  - scTCR-seq
-  - T-cell clonal expansion
-  - machine learning
-topics:
-  - immune
+  - immune receptor
+  - deep learning
 license: MIT
 version: v0.4.3
 contact:

--- a/packages/scanpro/meta.yaml
+++ b/packages/scanpro/meta.yaml
@@ -7,12 +7,10 @@ publications:
   - 10.1101/2023.08.14.553234
 install:
   pypi: scanpro
+primary_category: scRNA-seq
 tags:
-  - single cell
-  - proportion analysis
-  - multi omics
-topics:
-  - differential-analysis
+  - multimodal
+  - compositional analysis
 license: MIT
 version: 0.2.0
 contact:

--- a/packages/scanpro/meta.yaml
+++ b/packages/scanpro/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - multimodal
   - compositional analysis
 license: MIT
+language: Python
 version: 0.2.0
 contact:
   - yalayoubi

--- a/packages/scanpro/meta.yaml
+++ b/packages/scanpro/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - single cell
   - proportion analysis
   - multi omics
+topics:
+  - differential-analysis
 license: MIT
 version: 0.2.0
 contact:

--- a/packages/scanpy/meta.yaml
+++ b/packages/scanpy/meta.yaml
@@ -19,6 +19,7 @@ tags:
   - clustering
   - visualization
 license: BSD-3-Clause
+language: Python
 version: 1.11.5
 contact:
   - flying-sheep

--- a/packages/scanpy/meta.yaml
+++ b/packages/scanpy/meta.yaml
@@ -18,6 +18,11 @@ tags:
   - clustering
   - visualization
   - differential expression
+topics:
+  - preprocessing
+  - clustering
+  - differential-analysis
+  - visualization
 license: BSD-3-Clause
 version: 1.11.5
 contact:

--- a/packages/scanpy/meta.yaml
+++ b/packages/scanpy/meta.yaml
@@ -12,16 +12,11 @@ publications:
 install:
   pypi: scanpy
   conda: conda-forge::scanpy
+primary_category: scRNA-seq
 tags:
-  - single-cell
   - preprocessing
-  - clustering
-  - visualization
   - differential expression
-topics:
-  - preprocessing
   - clustering
-  - differential-analysis
   - visualization
 license: BSD-3-Clause
 version: 1.11.5

--- a/packages/schist/meta.yaml
+++ b/packages/schist/meta.yaml
@@ -9,6 +9,8 @@ license: BSD-3-Clause
 tags:
   - clustering
   - single-cell
+topics:
+  - clustering
 publications:
   - 10.1186/s12859-021-04489-7
 version: v0.8.1

--- a/packages/schist/meta.yaml
+++ b/packages/schist/meta.yaml
@@ -6,10 +6,8 @@ tutorials_home: https://schist.readthedocs.io/page/tutorials.html
 install:
   conda: conda-forge::schist
 license: BSD-3-Clause
+primary_category: scRNA-seq
 tags:
-  - clustering
-  - single-cell
-topics:
   - clustering
 publications:
   - 10.1186/s12859-021-04489-7

--- a/packages/schist/meta.yaml
+++ b/packages/schist/meta.yaml
@@ -6,6 +6,7 @@ tutorials_home: https://schist.readthedocs.io/page/tutorials.html
 install:
   conda: conda-forge::schist
 license: BSD-3-Clause
+language: Python
 primary_category: scRNA-seq
 tags:
   - clustering

--- a/packages/scib-rapids/meta.yaml
+++ b/packages/scib-rapids/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - benchmarking
   - GPU acceleration
 license: BSD-3-Clause
+language: Python
 version: 0.1.0
 contact:
   - maarten-devries

--- a/packages/scib-rapids/meta.yaml
+++ b/packages/scib-rapids/meta.yaml
@@ -6,14 +6,11 @@ project_home: https://github.com/maarten-devries/scib-rapids
 documentation_home: https://scib-rapids.readthedocs.io/
 install:
   pypi: scib-rapids
+primary_category: scRNA-seq
 tags:
-  - benchmarking
-  - single-cell
   - data integration
+  - benchmarking
   - GPU acceleration
-  - RAPIDS
-topics:
-  - integration
 license: BSD-3-Clause
 version: 0.1.0
 contact:

--- a/packages/scib-rapids/meta.yaml
+++ b/packages/scib-rapids/meta.yaml
@@ -12,6 +12,8 @@ tags:
   - data integration
   - GPU acceleration
   - RAPIDS
+topics:
+  - integration
 license: BSD-3-Clause
 version: 0.1.0
 contact:

--- a/packages/scib/meta.yaml
+++ b/packages/scib/meta.yaml
@@ -7,12 +7,10 @@ publications:
   - 10.1038/s41592-021-01336-8
 install:
   pypi: scib
+primary_category: scRNA-seq
 tags:
-  - benchmarking
-  - single cell
   - data integration
-topics:
-  - integration
+  - benchmarking
 license: MIT
 version: v1.0.5
 contact:

--- a/packages/scib/meta.yaml
+++ b/packages/scib/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - benchmarking
   - single cell
   - data integration
+topics:
+  - integration
 license: MIT
 version: v1.0.5
 contact:

--- a/packages/scib/meta.yaml
+++ b/packages/scib/meta.yaml
@@ -12,6 +12,7 @@ tags:
   - data integration
   - benchmarking
 license: MIT
+language: Python
 version: v1.0.5
 contact:
   - mumichae

--- a/packages/scirpy/meta.yaml
+++ b/packages/scirpy/meta.yaml
@@ -16,6 +16,8 @@ tags:
   - TCR
   - BCR
   - AIRR
+topics:
+  - immune
 license: BSD-3-Clause
 version: 0.22.3
 contact:

--- a/packages/scirpy/meta.yaml
+++ b/packages/scirpy/meta.yaml
@@ -11,13 +11,9 @@ publications:
 install:
   pypi: scirpy
   conda: bioconda::scirpy
+primary_category: Adaptive immune cell receptor
 tags:
   - immune receptor
-  - TCR
-  - BCR
-  - AIRR
-topics:
-  - immune
 license: BSD-3-Clause
 version: 0.22.3
 contact:

--- a/packages/scirpy/meta.yaml
+++ b/packages/scirpy/meta.yaml
@@ -15,6 +15,7 @@ primary_category: Adaptive immune cell receptor
 tags:
   - immune receptor
 license: BSD-3-Clause
+language: Python
 version: 0.22.3
 contact:
   - grst

--- a/packages/scmcp/meta.yaml
+++ b/packages/scmcp/meta.yaml
@@ -9,6 +9,8 @@ tags:
   - bioinformatics
   - LLM
   - AI
+topics:
+  - infrastructure
 license: BSD-3-Clause
 version: v0.2.2
 contact:

--- a/packages/scmcp/meta.yaml
+++ b/packages/scmcp/meta.yaml
@@ -8,6 +8,7 @@ primary_category: Infrastructure
 tags:
   - large language models
 license: BSD-3-Clause
+language: Python
 version: v0.2.2
 contact:
   - huangsh

--- a/packages/scmcp/meta.yaml
+++ b/packages/scmcp/meta.yaml
@@ -4,13 +4,9 @@ project_home: https://github.com/scmcphub
 documentation_home: https://docs.scmcphub.org
 install:
   pypi: scmcp
+primary_category: Infrastructure
 tags:
-  - scRNA-seq
-  - bioinformatics
-  - LLM
-  - AI
-topics:
-  - infrastructure
+  - large language models
 license: BSD-3-Clause
 version: v0.2.2
 contact:

--- a/packages/sctriangulate/meta.yaml
+++ b/packages/sctriangulate/meta.yaml
@@ -10,6 +10,8 @@ install:
   pypi: sctriangulate
 tags:
   - clustering
+topics:
+  - clustering
 license: MIT
 version: v0.12.0
 contact:

--- a/packages/sctriangulate/meta.yaml
+++ b/packages/sctriangulate/meta.yaml
@@ -12,6 +12,7 @@ primary_category: scRNA-seq
 tags:
   - clustering
 license: MIT
+language: Python
 version: v0.12.0
 contact:
   - frankligy

--- a/packages/sctriangulate/meta.yaml
+++ b/packages/sctriangulate/meta.yaml
@@ -8,9 +8,8 @@ publications:
   - 10.1101/2021.10.16.464640
 install:
   pypi: sctriangulate
+primary_category: scRNA-seq
 tags:
-  - clustering
-topics:
   - clustering
 license: MIT
 version: v0.12.0

--- a/packages/scvelo/meta.yaml
+++ b/packages/scvelo/meta.yaml
@@ -7,10 +7,9 @@ publications:
   - 10.1038/s41587-020-0591-3
 install:
   pypi: scvelo
+primary_category: scRNA-seq
 tags:
-  - rna velocity
-topics:
-  - trajectory
+  - RNA velocity
 license: BSD-3-Clause
 version: v0.2.5
 contact:

--- a/packages/scvelo/meta.yaml
+++ b/packages/scvelo/meta.yaml
@@ -9,6 +9,8 @@ install:
   pypi: scvelo
 tags:
   - rna velocity
+topics:
+  - trajectory
 license: BSD-3-Clause
 version: v0.2.5
 contact:

--- a/packages/scvelo/meta.yaml
+++ b/packages/scvelo/meta.yaml
@@ -11,6 +11,7 @@ primary_category: scRNA-seq
 tags:
   - RNA velocity
 license: BSD-3-Clause
+language: Python
 version: v0.2.5
 contact:
   - WeilerP

--- a/packages/scverse-tutorials/meta.yaml
+++ b/packages/scverse-tutorials/meta.yaml
@@ -4,12 +4,9 @@ description: |
 project_home: https://github.com/scverse/scverse-tutorials
 documentation_home: https://scverse-tutorials.readthedocs.io/
 tutorials_home: https://scverse-tutorials.readthedocs.io/
+primary_category: Infrastructure
 tags:
-  - tutorials
-  - education
   - documentation
-topics:
-  - infrastructure
 license: BSD-3-Clause
 contact:
   - grst

--- a/packages/scverse-tutorials/meta.yaml
+++ b/packages/scverse-tutorials/meta.yaml
@@ -8,6 +8,8 @@ tags:
   - tutorials
   - education
   - documentation
+topics:
+  - infrastructure
 license: BSD-3-Clause
 contact:
   - grst

--- a/packages/scverse-tutorials/meta.yaml
+++ b/packages/scverse-tutorials/meta.yaml
@@ -8,6 +8,7 @@ primary_category: Infrastructure
 tags:
   - documentation
 license: BSD-3-Clause
+language: Python
 contact:
   - grst
   - flying-sheep

--- a/packages/scverse.github.io/meta.yaml
+++ b/packages/scverse.github.io/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - documentation
 license: BSD-3-Clause
+language: Python
 authors:
   - gtca
 category: core-infrastructure

--- a/packages/scverse.github.io/meta.yaml
+++ b/packages/scverse.github.io/meta.yaml
@@ -3,11 +3,9 @@ description: |
   scverse.org website
 project_home: https://github.com/scverse/scverse.github.io
 documentation_home: https://scverse.org
+primary_category: Infrastructure
 tags:
-  - website
   - documentation
-topics:
-  - infrastructure
 license: BSD-3-Clause
 authors:
   - gtca

--- a/packages/scverse.github.io/meta.yaml
+++ b/packages/scverse.github.io/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://scverse.org
 tags:
   - website
   - documentation
+topics:
+  - infrastructure
 license: BSD-3-Clause
 authors:
   - gtca

--- a/packages/scvi-tools/meta.yaml
+++ b/packages/scvi-tools/meta.yaml
@@ -34,6 +34,10 @@ tags:
   - probabilistic models
   - variational inference
   - deep learning
+topics:
+  - integration
+  - annotation
+  - differential-analysis
 license: BSD-3-Clause
 version: 1.4.0.post1
 contact:

--- a/packages/scvi-tools/meta.yaml
+++ b/packages/scvi-tools/meta.yaml
@@ -29,15 +29,13 @@ publications:
 install:
   pypi: scvi-tools
   conda: conda-forge::scvi-tools
+primary_category: scRNA-seq
 tags:
-  - machine learning
-  - probabilistic models
-  - variational inference
+  - data integration
+  - cell-type annotation
+  - differential expression
   - deep learning
-topics:
-  - integration
-  - annotation
-  - differential-analysis
+  - probabilistic modeling
 license: BSD-3-Clause
 version: 1.4.0.post1
 contact:

--- a/packages/scvi-tools/meta.yaml
+++ b/packages/scvi-tools/meta.yaml
@@ -37,6 +37,7 @@ tags:
   - deep learning
   - probabilistic modeling
 license: BSD-3-Clause
+language: Python
 version: 1.4.0.post1
 contact:
   - ori-kron-wis

--- a/packages/scxmatch/meta.yaml
+++ b/packages/scxmatch/meta.yaml
@@ -17,6 +17,9 @@ tags:
   - distance-based matching
   - perturbation
   - condition
+topics:
+  - perturbation
+  - differential-analysis
 license: MIT
 version: v0.1.0
 contact:

--- a/packages/scxmatch/meta.yaml
+++ b/packages/scxmatch/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - perturbation
   - probabilistic modeling
 license: MIT
+language: Python
 version: v0.1.0
 contact:
   - annmoel

--- a/packages/scxmatch/meta.yaml
+++ b/packages/scxmatch/meta.yaml
@@ -9,17 +9,11 @@ publications:
   - 10.1101/2025.06.25.661473
 install:
   conda: bioconda::scxmatch
+primary_category: scRNA-seq
 tags:
   - scRNA-seq
-  - single-cell
-  - python
-  - statistical testing
-  - distance-based matching
   - perturbation
-  - condition
-topics:
-  - perturbation
-  - differential-analysis
+  - probabilistic modeling
 license: MIT
 version: v0.1.0
 contact:

--- a/packages/scyan/meta.yaml
+++ b/packages/scyan/meta.yaml
@@ -10,15 +10,11 @@ publications:
   - 10.1093/bib/bbad260
 install:
   pypi: scyan
+primary_category: Proteomics
 tags:
-  - cytometry
-  - annotation
-  - batch-effect correction
-  - debarcoding
-topics:
-  - proteomics
-  - annotation
-  - integration
+  - flow cytometry
+  - data integration
+  - cell-type annotation
 license: BSD-3-Clause
 version: v1.5.0
 contact:

--- a/packages/scyan/meta.yaml
+++ b/packages/scyan/meta.yaml
@@ -15,6 +15,10 @@ tags:
   - annotation
   - batch-effect correction
   - debarcoding
+topics:
+  - proteomics
+  - annotation
+  - integration
 license: BSD-3-Clause
 version: v1.5.0
 contact:

--- a/packages/scyan/meta.yaml
+++ b/packages/scyan/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - data integration
   - cell-type annotation
 license: BSD-3-Clause
+language: Python
 version: v1.5.0
 contact:
   - quentinblampey

--- a/packages/sift-sc/meta.yaml
+++ b/packages/sift-sc/meta.yaml
@@ -7,11 +7,8 @@ documentation_home: https://sift-sc.readthedocs.io/
 tutorials_home: https://sift-sc.readthedocs.io/
 install:
   pypi: sift-sc
+primary_category: scRNA-seq
 tags:
-  - single-cell
-  - signals
-  - filter
-topics:
   - preprocessing
 license: BSD-3-Clause
 version: v0.1.0

--- a/packages/sift-sc/meta.yaml
+++ b/packages/sift-sc/meta.yaml
@@ -11,6 +11,8 @@ tags:
   - single-cell
   - signals
   - filter
+topics:
+  - preprocessing
 license: BSD-3-Clause
 version: v0.1.0
 contact:

--- a/packages/sift-sc/meta.yaml
+++ b/packages/sift-sc/meta.yaml
@@ -11,6 +11,7 @@ primary_category: scRNA-seq
 tags:
   - preprocessing
 license: BSD-3-Clause
+language: Python
 version: v0.1.0
 contact:
   - zoepiran

--- a/packages/sincei/meta.yaml
+++ b/packages/sincei/meta.yaml
@@ -21,6 +21,7 @@ tags:
   - visualization
   - file formats
 license: MIT
+language: Python
 version: v0.5.1
 authors:
   - vivekbhr

--- a/packages/sincei/meta.yaml
+++ b/packages/sincei/meta.yaml
@@ -20,6 +20,10 @@ tags:
   - epigenomics
   - multi omics
   - BAM
+topics:
+  - epigenomics
+  - preprocessing
+  - clustering
 license: MIT
 version: v0.5.1
 authors:

--- a/packages/sincei/meta.yaml
+++ b/packages/sincei/meta.yaml
@@ -11,19 +11,15 @@ publications:
   - 10.1101/2024.07.27.605424
 install:
   pypi: sincei
+primary_category: Epigenomics
 tags:
-  - single-cell
+  - epigenomics
+  - multimodal
   - preprocessing
   - quality control
   - clustering
   - visualization
-  - epigenomics
-  - multi omics
-  - BAM
-topics:
-  - epigenomics
-  - preprocessing
-  - clustering
+  - file formats
 license: MIT
 version: v0.5.1
 authors:

--- a/packages/sobolev-alignment/meta.yaml
+++ b/packages/sobolev-alignment/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - pre-clinical
   - clinical
   - scrnaseq
+topics:
+  - integration
 license: MIT
 version: 1.0.0
 contact:

--- a/packages/sobolev-alignment/meta.yaml
+++ b/packages/sobolev-alignment/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - deep learning
   - probabilistic modeling
 license: MIT
+language: Python
 version: 1.0.0
 contact:
   - saroudant

--- a/packages/sobolev-alignment/meta.yaml
+++ b/packages/sobolev-alignment/meta.yaml
@@ -7,15 +7,11 @@ publications:
   - 10.1101/2022.03.08.483431
 install:
   pypi: sobolev-alignment
+primary_category: scRNA-seq
 tags:
-  - ML
-  - deep-generative-models
-  - kernel-methods
-  - pre-clinical
-  - clinical
-  - scrnaseq
-topics:
-  - integration
+  - scRNA-seq
+  - deep learning
+  - probabilistic modeling
 license: MIT
 version: 1.0.0
 contact:

--- a/packages/sopa/meta.yaml
+++ b/packages/sopa/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - imaging
   - pipeline
 license: BSD-3-Clause
+language: Python
 version: v1.0.0
 contact:
   - quentinblampey

--- a/packages/sopa/meta.yaml
+++ b/packages/sopa/meta.yaml
@@ -15,6 +15,9 @@ tags:
   - multiplex imaging
   - spatialdata
   - pipeline
+topics:
+  - spatial
+  - imaging
 license: BSD-3-Clause
 version: v1.0.0
 contact:

--- a/packages/sopa/meta.yaml
+++ b/packages/sopa/meta.yaml
@@ -9,15 +9,11 @@ publications:
   - 10.1038/s41467-024-48981-z
 install:
   pypi: sopa
+primary_category: Spatial
 tags:
-  - spatial-omics
-  - spatial-transcriptomics
-  - multiplex imaging
-  - spatialdata
-  - pipeline
-topics:
-  - spatial
+  - spatial transcriptomics
   - imaging
+  - pipeline
 license: BSD-3-Clause
 version: v1.0.0
 contact:

--- a/packages/spatial-eggplant/meta.yaml
+++ b/packages/spatial-eggplant/meta.yaml
@@ -8,12 +8,10 @@ publications:
   - 10.1101/2021.11.11.468178
 install:
   pypi: spatial-eggplant
+primary_category: Spatial
 tags:
-  - spatial alignment
-  - spatial registration
-topics:
-  - spatial
-  - integration
+  - spatial transcriptomics
+  - data integration
 license: MIT
 version: v0.2.3
 contact:

--- a/packages/spatial-eggplant/meta.yaml
+++ b/packages/spatial-eggplant/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - spatial transcriptomics
   - data integration
 license: MIT
+language: Python
 version: v0.2.3
 contact:
   - almaan

--- a/packages/spatial-eggplant/meta.yaml
+++ b/packages/spatial-eggplant/meta.yaml
@@ -11,6 +11,9 @@ install:
 tags:
   - spatial alignment
   - spatial registration
+topics:
+  - spatial
+  - integration
 license: MIT
 version: v0.2.3
 contact:

--- a/packages/spatialdata/meta.yaml
+++ b/packages/spatialdata/meta.yaml
@@ -10,13 +10,11 @@ publications:
   - 10.1038/s41592-024-02212-x
 install:
   pypi: spatialdata
+primary_category: Data structures
 tags:
-  - data structure
-  - spatial omics
-  - FAIR
-topics:
-  - spatial
-  - infrastructure
+  - spatial transcriptomics
+  - data structures
+  - file formats
 license: BSD-3-Clause
 version: 0.5.0
 contact:

--- a/packages/spatialdata/meta.yaml
+++ b/packages/spatialdata/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - data structures
   - file formats
 license: BSD-3-Clause
+language: Python
 version: 0.5.0
 contact:
   - LucaMarconato

--- a/packages/spatialdata/meta.yaml
+++ b/packages/spatialdata/meta.yaml
@@ -14,6 +14,9 @@ tags:
   - data structure
   - spatial omics
   - FAIR
+topics:
+  - spatial
+  - infrastructure
 license: BSD-3-Clause
 version: 0.5.0
 contact:

--- a/packages/spatialproteomics/meta.yaml
+++ b/packages/spatialproteomics/meta.yaml
@@ -15,6 +15,7 @@ tags:
   - imaging
   - pipeline
 license: MIT
+language: Python
 version: v0.7.0
 contact:
   - MeyerBender

--- a/packages/spatialproteomics/meta.yaml
+++ b/packages/spatialproteomics/meta.yaml
@@ -8,16 +8,12 @@ documentation_home: https://sagar87.github.io/spatialproteomics
 tutorials_home: https://sagar87.github.io/spatialproteomics/notebooks/ExampleWorkflow.html
 install:
   pypi: spatialproteomics
+primary_category: Spatial
 tags:
-  - spatial-omics
-  - spatial-proteomics
-  - multiplex imaging
-  - spatialdata
-  - pipeline
-topics:
-  - spatial
-  - proteomics
+  - spatial transcriptomics
+  - spatial proteomics
   - imaging
+  - pipeline
 license: MIT
 version: v0.7.0
 contact:

--- a/packages/spatialproteomics/meta.yaml
+++ b/packages/spatialproteomics/meta.yaml
@@ -14,6 +14,10 @@ tags:
   - multiplex imaging
   - spatialdata
   - pipeline
+topics:
+  - spatial
+  - proteomics
+  - imaging
 license: MIT
 version: v0.7.0
 contact:

--- a/packages/spatiomic/meta.yaml
+++ b/packages/spatiomic/meta.yaml
@@ -6,18 +6,12 @@ documentation_home: https://spatiomic.org
 tutorials_home: https://spatiomic.org/latest/tutorials/full_example.html
 install:
   pypi: spatiomic
+primary_category: Spatial
 tags:
-  - spatial biology
+  - spatial transcriptomics
   - spatial proteomics
-  - spatial omics
-  - multiplexed protein imaging
-  - PathoPlex
-  - subcellular analysis
-topics:
-  - spatial
-  - proteomics
   - imaging
-  - clustering
+  - segmentation
 license: GPL-3.0-only
 version: v0.5.0
 contact:

--- a/packages/spatiomic/meta.yaml
+++ b/packages/spatiomic/meta.yaml
@@ -13,6 +13,11 @@ tags:
   - multiplexed protein imaging
   - PathoPlex
   - subcellular analysis
+topics:
+  - spatial
+  - proteomics
+  - imaging
+  - clustering
 license: GPL-3.0-only
 version: v0.5.0
 contact:

--- a/packages/spatiomic/meta.yaml
+++ b/packages/spatiomic/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - imaging
   - segmentation
 license: GPL-3.0-only
+language: Python
 version: v0.5.0
 contact:
   - maltekuehl

--- a/packages/squidpy/meta.yaml
+++ b/packages/squidpy/meta.yaml
@@ -12,14 +12,10 @@ publications:
 install:
   pypi: squidpy
   conda: conda-forge::squidpy
+primary_category: Spatial
 tags:
-  - spatial omics
   - spatial transcriptomics
-  - image analysis
-topics:
-  - spatial
   - imaging
-  - visualization
 license: BSD-3-Clause
 version: 1.6.5
 contact:

--- a/packages/squidpy/meta.yaml
+++ b/packages/squidpy/meta.yaml
@@ -16,6 +16,10 @@ tags:
   - spatial omics
   - spatial transcriptomics
   - image analysis
+topics:
+  - spatial
+  - imaging
+  - visualization
 license: BSD-3-Clause
 version: 1.6.5
 contact:

--- a/packages/squidpy/meta.yaml
+++ b/packages/squidpy/meta.yaml
@@ -17,6 +17,7 @@ tags:
   - spatial transcriptomics
   - imaging
 license: BSD-3-Clause
+language: Python
 version: 1.6.5
 contact:
   - giovp

--- a/packages/stats/meta.yaml
+++ b/packages/stats/meta.yaml
@@ -7,6 +7,7 @@ primary_category: Infrastructure
 tags:
   - benchmarking
 license: MIT
+language: Python
 authors:
   - maltekuehl
   - grst

--- a/packages/stats/meta.yaml
+++ b/packages/stats/meta.yaml
@@ -3,11 +3,9 @@ description: |
   Statistics for scverse
 project_home: https://github.com/scverse/stats
 documentation_home: https://scverse.org/stats/
+primary_category: Infrastructure
 tags:
-  - statistics
-  - metrics
-topics:
-  - infrastructure
+  - benchmarking
 license: MIT
 authors:
   - maltekuehl

--- a/packages/stats/meta.yaml
+++ b/packages/stats/meta.yaml
@@ -6,6 +6,8 @@ documentation_home: https://scverse.org/stats/
 tags:
   - statistics
   - metrics
+topics:
+  - infrastructure
 license: MIT
 authors:
   - maltekuehl

--- a/packages/symphonypy/meta.yaml
+++ b/packages/symphonypy/meta.yaml
@@ -6,11 +6,9 @@ project_home: https://github.com/potulabe/symphonypy
 documentation_home: https://github.com/potulabe/symphonypy
 install:
   pypi: symphonypy
+primary_category: scRNA-seq
 tags:
-  - label-transfer
-topics:
-  - annotation
-  - integration
+  - cell-type annotation
 license: GPL-3.0-only
 version: v0.2.1
 contact:

--- a/packages/symphonypy/meta.yaml
+++ b/packages/symphonypy/meta.yaml
@@ -8,6 +8,9 @@ install:
   pypi: symphonypy
 tags:
   - label-transfer
+topics:
+  - annotation
+  - integration
 license: GPL-3.0-only
 version: v0.2.1
 contact:

--- a/packages/symphonypy/meta.yaml
+++ b/packages/symphonypy/meta.yaml
@@ -10,6 +10,7 @@ primary_category: scRNA-seq
 tags:
   - cell-type annotation
 license: GPL-3.0-only
+language: Python
 version: v0.2.1
 contact:
   - serjisa

--- a/packages/tangram/meta.yaml
+++ b/packages/tangram/meta.yaml
@@ -11,6 +11,9 @@ install:
 tags:
   - spatial decomposition
   - spatial mapping
+topics:
+  - spatial
+  - integration
 license: BSD-3-Clause
 version: v1.0.3
 contact:

--- a/packages/tangram/meta.yaml
+++ b/packages/tangram/meta.yaml
@@ -8,12 +8,10 @@ publications:
   - 10.1038/s41592-021-01264-7
 install:
   pypi: tangram-sc
+primary_category: Spatial
 tags:
-  - spatial decomposition
-  - spatial mapping
-topics:
-  - spatial
-  - integration
+  - spatial transcriptomics
+  - deconvolution
 license: BSD-3-Clause
 version: v1.0.3
 contact:

--- a/packages/tangram/meta.yaml
+++ b/packages/tangram/meta.yaml
@@ -13,6 +13,7 @@ tags:
   - spatial transcriptomics
   - deconvolution
 license: BSD-3-Clause
+language: Python
 version: v1.0.3
 contact:
   - ziqlu0722

--- a/packages/tau-community-detection/meta.yaml
+++ b/packages/tau-community-detection/meta.yaml
@@ -9,6 +9,7 @@ documentation_home: https://github.com/HillelCharbit/TAU#readme
 install:
   pypi: tau-community-detection
 license: MIT
+language: Python
 primary_category: scRNA-seq
 tags:
   - clustering

--- a/packages/tau-community-detection/meta.yaml
+++ b/packages/tau-community-detection/meta.yaml
@@ -9,14 +9,8 @@ documentation_home: https://github.com/HillelCharbit/TAU#readme
 install:
   pypi: tau-community-detection
 license: MIT
+primary_category: scRNA-seq
 tags:
-  - community-detection
-  - clustering
-  - single-cell
-  - scanpy
-  - anndata
-  - graph-analysis
-topics:
   - clustering
 publications:
   - 10.1093/pnasnexus/pgad180

--- a/packages/tau-community-detection/meta.yaml
+++ b/packages/tau-community-detection/meta.yaml
@@ -16,6 +16,8 @@ tags:
   - scanpy
   - anndata
   - graph-analysis
+topics:
+  - clustering
 publications:
   - 10.1093/pnasnexus/pgad180
 version: 1.4.7

--- a/packages/vitessce/meta.yaml
+++ b/packages/vitessce/meta.yaml
@@ -9,12 +9,12 @@ publications:
   - 10.1038/s41592-024-02436-x
 install:
   pypi: vitessce
+primary_category: Spatial
 tags:
+  - spatial transcriptomics
   - imaging
-topics:
+  - multimodal
   - visualization
-  - spatial
-  - imaging
 license: MIT
 version: v3.5.7
 contact:

--- a/packages/vitessce/meta.yaml
+++ b/packages/vitessce/meta.yaml
@@ -11,6 +11,10 @@ install:
   pypi: vitessce
 tags:
   - imaging
+topics:
+  - visualization
+  - spatial
+  - imaging
 license: MIT
 version: v3.5.7
 contact:

--- a/packages/vitessce/meta.yaml
+++ b/packages/vitessce/meta.yaml
@@ -16,6 +16,7 @@ tags:
   - multimodal
   - visualization
 license: MIT
+language: Python
 version: v3.5.7
 contact:
   - keller-mark

--- a/packages/wsidata/meta.yaml
+++ b/packages/wsidata/meta.yaml
@@ -8,6 +8,9 @@ install:
 tags:
   - Pathology
   - Whole Slide Imaging
+topics:
+  - imaging
+  - infrastructure
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/wsidata/meta.yaml
+++ b/packages/wsidata/meta.yaml
@@ -11,6 +11,7 @@ tags:
   - data structures
   - file formats
 license: MIT
+language: Python
 version: v0.3.0
 contact:
   - Mr-Milk

--- a/packages/wsidata/meta.yaml
+++ b/packages/wsidata/meta.yaml
@@ -5,12 +5,11 @@ project_home: https://github.com/rendeirolab/wsidata
 documentation_home: https://wsidata.readthedocs.io/
 install:
   pypi: wsidata
+primary_category: Data structures
 tags:
-  - Pathology
-  - Whole Slide Imaging
-topics:
   - imaging
-  - infrastructure
+  - data structures
+  - file formats
 license: MIT
 version: v0.3.0
 contact:

--- a/packages/zellkonverter/meta.yaml
+++ b/packages/zellkonverter/meta.yaml
@@ -14,6 +14,8 @@ tags:
   - interoperability
   - R
   - Bioconductor
+topics:
+  - infrastructure
 version: 1.20.0
 contact:
   - lazappi

--- a/packages/zellkonverter/meta.yaml
+++ b/packages/zellkonverter/meta.yaml
@@ -9,13 +9,11 @@ tutorials_home: https://theislab.github.io/zellkonverter/
 install:
   bioconductor: zellkonverter
 license: MIT
+language: R
+primary_category: Data structures
 tags:
   - data structures
   - interoperability
-  - R
-  - Bioconductor
-topics:
-  - infrastructure
 version: 1.20.0
 contact:
   - lazappi

--- a/scripts/src/ecosystem_scripts/schema.json
+++ b/scripts/src/ecosystem_scripts/schema.json
@@ -186,44 +186,84 @@
                 "ZPL-2.1"
             ]
         },
-        "tags": {
-            "description": "Keywords that describe the package",
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1,
-            "uniqueItems": true
+        "primary_category": {
+            "description": "The single category the package is listed under on scverse.org/packages. Pick the one a user looking for this package would browse first.",
+            "type": "string",
+            "enum": [
+                "Data structures",
+                "scRNA-seq",
+                "bulk RNA-seq",
+                "Spatial",
+                "Epigenomics",
+                "Proteomics",
+                "Adaptive immune cell receptor",
+                "Multimodal",
+                "Imaging",
+                "Infrastructure"
+            ]
         },
-        "topics": {
-            "description": "What the package is for, from a controlled vocabulary. Drives the filters on scverse.org/packages. Pick every topic that genuinely applies, usually one to three. Propose additions in a pull request.",
+        "tags": {
+            "description": "What the package does, from a controlled vocabulary. Used for filtering and search on scverse.org/packages. Pick every tag that genuinely applies. If none of them fit, add a term to this enum in your pull request.",
             "type": "array",
             "items": {
                 "type": "string",
                 "enum": [
-                    "annotation",
-                    "cell-communication",
-                    "clustering",
-                    "deconvolution",
-                    "differential-analysis",
-                    "epigenomics",
-                    "gene-networks",
-                    "imaging",
-                    "immune",
-                    "infrastructure",
-                    "integration",
-                    "multi-omics",
-                    "perturbation",
-                    "preprocessing",
+                    "scRNA-seq",
+                    "bulk RNA-seq",
+                    "spatial transcriptomics",
+                    "spatial proteomics",
                     "proteomics",
-                    "spatial",
-                    "trajectory",
-                    "visualization"
+                    "flow cytometry",
+                    "ATAC-seq",
+                    "epigenomics",
+                    "immune receptor",
+                    "imaging",
+                    "multimodal",
+                    "preprocessing",
+                    "quality control",
+                    "denoising",
+                    "data integration",
+                    "cell-type annotation",
+                    "differential expression",
+                    "compositional analysis",
+                    "functional analysis",
+                    "gene regulatory networks",
+                    "cell-cell communication",
+                    "deconvolution",
+                    "clustering",
+                    "dimensionality reduction",
+                    "trajectory inference",
+                    "pseudotime",
+                    "RNA velocity",
+                    "lineage tracing",
+                    "perturbation",
+                    "spatially variable genes",
+                    "segmentation",
+                    "copy number variation",
+                    "visualization",
+                    "benchmarking",
+                    "deep learning",
+                    "foundation model",
+                    "large language models",
+                    "probabilistic modeling",
+                    "optimal transport",
+                    "GPU acceleration",
+                    "pipeline",
+                    "data structures",
+                    "interoperability",
+                    "file formats",
+                    "documentation"
                 ]
             },
             "minItems": 1,
-            "maxItems": 4,
+            "maxItems": 10,
             "uniqueItems": true
+        },
+        "language": {
+            "description": "Language a user writes code in when using the package. Assumed to be Python when omitted.",
+            "type": "string",
+            "default": "Python",
+            "enum": ["Python", "R", "Julia", "Rust"]
         },
         "publications": {
             "description": "DOIs of publications describing the package",
@@ -274,7 +314,7 @@
         "documentation_home",
         "license",
         "tags",
-        "topics",
+        "primary_category",
         "category"
     ],
     "if": {

--- a/scripts/src/ecosystem_scripts/schema.json
+++ b/scripts/src/ecosystem_scripts/schema.json
@@ -260,9 +260,8 @@
             "uniqueItems": true
         },
         "language": {
-            "description": "Language a user writes code in when using the package. Assumed to be Python when omitted.",
+            "description": "Language a user writes code in when using the package.",
             "type": "string",
-            "default": "Python",
             "enum": ["Python", "R", "Julia", "Rust"]
         },
         "publications": {
@@ -315,6 +314,7 @@
         "license",
         "tags",
         "primary_category",
+        "language",
         "category"
     ],
     "if": {

--- a/scripts/src/ecosystem_scripts/schema.json
+++ b/scripts/src/ecosystem_scripts/schema.json
@@ -195,6 +195,36 @@
             "minItems": 1,
             "uniqueItems": true
         },
+        "topics": {
+            "description": "What the package is for, from a controlled vocabulary. Drives the filters on scverse.org/packages. Pick every topic that genuinely applies, usually one to three. Propose additions in a pull request.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "annotation",
+                    "cell-communication",
+                    "clustering",
+                    "deconvolution",
+                    "differential-analysis",
+                    "epigenomics",
+                    "gene-networks",
+                    "imaging",
+                    "immune",
+                    "infrastructure",
+                    "integration",
+                    "multi-omics",
+                    "perturbation",
+                    "preprocessing",
+                    "proteomics",
+                    "spatial",
+                    "trajectory",
+                    "visualization"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 4,
+            "uniqueItems": true
+        },
         "publications": {
             "description": "DOIs of publications describing the package",
             "type": "array",
@@ -244,6 +274,7 @@
         "documentation_home",
         "license",
         "tags",
+        "topics",
         "category"
     ],
     "if": {


### PR DESCRIPTION
Closes scverse/scverse.github.io#106, closes #299, closes #46.

- **`tags`** — 45-term enum, folded from the 250 existing tags, dropping the non-descriptive ones (`python`, `single-cell`, `bioinformatics`, `utilities`, library names). Drives filtering and search.
- **`primary_category`** — the one category a package is listed under, for grouping.
- **`language`** — now mandatory to ensure that the schema is complete and doesn't break in random places.

Both vocabularies mirror the [tutorial registry](https://github.com/scverse/scverse-tutorials/blob/main/tutorial-registry/schema.json), which already has `primary_category` plus a controlled `tags` enum, so the two registries share terminology. New terms get added to the enum in the PR that needs them.

**This breaks the open PRs by design:** #391, #388, #385, #382, #378, #376, #375, #373, #372, #371, #368, #367, #364, #349, #348 and #327 need their `tags` moved onto the vocabulary and a `primary_category` added.
