### PR TITLE
Update publication DOIs from preprint to published versions

### DIFF
--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -9,7 +9,6 @@ documentation_home: https://github.com/ratschlab/aestetik#readme
 tutorials_home: https://github.com/ratschlab/aestetik/tree/main/example
 publications:
   - 10.1093/bioinformatics/btag316
-  - 10.1101/2024.06.04.24308256
 install:
   pypi: aestetik
 primary_category: Spatial

--- a/packages/CellOracle/meta.yaml
+++ b/packages/CellOracle/meta.yaml
@@ -6,7 +6,7 @@ project_home: https://github.com/morris-lab/CellOracle
 documentation_home: https://morris-lab.github.io/CellOracle.documentation/
 tutorials_home: https://morris-lab.github.io/CellOracle.documentation/
 publications:
-  - 10.1101/2020.02.17.947416
+  - 10.1038/s41586-022-05688-9
 install:
   pypi: celloracle
 primary_category: Epigenomics

--- a/packages/GRnnData/meta.yaml
+++ b/packages/GRnnData/meta.yaml
@@ -5,7 +5,7 @@ description: |
 project_home: https://github.com/cantinilab/GRnnData
 documentation_home: https://cantinilab.github.io/GRnnData/
 publications:
-  - 10.1101/2024.07.29.605556
+  - 10.1038/s41467-025-58699-1
 install:
   pypi: grnndata
 primary_category: Data structures

--- a/packages/Mowgli/meta.yaml
+++ b/packages/Mowgli/meta.yaml
@@ -4,7 +4,7 @@ description: |
 project_home: https://github.com/cantinilab/mowgli
 documentation_home: https://mowgli.readthedocs.io/
 publications:
-  - 10.1101/2023.02.02.526825
+  - 10.1038/s41467-023-43019-2
 install:
   pypi: mowgli
 primary_category: Multimodal

--- a/packages/PEAKQC/meta.yaml
+++ b/packages/PEAKQC/meta.yaml
@@ -3,7 +3,7 @@ description: periodicity evaluation in scATAC-seq data for quality assessment
 project_home: https://github.com/loosolab/PEAKQC
 documentation_home: https://loosolab.pages.gwdg.de/software/peakqc/
 publications:
-  - 10.1101/2025.02.20.639146
+  - 10.1093/bib/bbaf465
 install:
   pypi: peakqc
 primary_category: Epigenomics

--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -14,7 +14,7 @@ tags:
   - bulk RNA-seq
   - differential expression
 publications:
-  - 10.1101/2022.12.14.520412
+  - 10.1093/bioinformatics/btad547
 version: v0.3.0
 contact:
   - BorisMuzellec

--- a/packages/anndata/meta.yaml
+++ b/packages/anndata/meta.yaml
@@ -7,7 +7,7 @@ project_home: https://github.com/scverse/anndata
 documentation_home: https://anndata.scverse.org/
 tutorials_home: https://anndata.scverse.org/page/tutorials/
 publications:
-  - 10.1101/2021.12.16.473007
+  - 10.21105/joss.04371
 install:
   pypi: anndata
   conda: conda-forge::anndata

--- a/packages/anndataR/meta.yaml
+++ b/packages/anndataR/meta.yaml
@@ -14,7 +14,7 @@ tags:
   - data structures
   - interoperability
 publications:
-  - 10.1101/2025.08.18.669052 # bioRxiv preprint
+  - 10.1093/bioinformatics/btag288
 version: 1.0.0
 contact:
   - lazappi

--- a/packages/benGRN/meta.yaml
+++ b/packages/benGRN/meta.yaml
@@ -5,7 +5,7 @@ description: |
 project_home: https://github.com/jkobject/benGRN
 documentation_home: https://www.jkobject.com/benGRN
 publications:
-  - 10.1101/2024.07.29.605556
+  - 10.1038/s41467-025-58699-1
 install:
   pypi: bengrn
 primary_category: scRNA-seq

--- a/packages/bento-tools/meta.yaml
+++ b/packages/bento-tools/meta.yaml
@@ -5,7 +5,7 @@ project_home: https://github.com/ckmah/bento-tools
 documentation_home: https://bento-tools.readthedocs.io/
 tutorials_home: https://bento-tools.readthedocs.io/page/tutorials.html
 publications:
-  - 10.1101/2022.06.10.495510
+  - 10.1186/s13059-024-03217-7
 install:
   pypi: bento-tools
 primary_category: Spatial

--- a/packages/moscot/meta.yaml
+++ b/packages/moscot/meta.yaml
@@ -4,7 +4,7 @@ description: |
 project_home: https://github.com/theislab/moscot
 documentation_home: https://moscot.readthedocs.io/page/
 publications:
-  - 10.1101/2023.05.11.540374
+  - 10.1038/s41586-024-08453-2
 install:
   pypi: moscot
 primary_category: Multimodal

--- a/packages/novae/meta.yaml
+++ b/packages/novae/meta.yaml
@@ -5,7 +5,7 @@ description: |
 project_home: https://github.com/prism-oncology/novae
 documentation_home: https://prism-oncology.github.io/novae/
 publications:
-  - 10.1101/2024.09.09.612009
+  - 10.1038/s41592-025-02899-6
 install:
   pypi: novae
 primary_category: Spatial

--- a/packages/omicverse/meta.yaml
+++ b/packages/omicverse/meta.yaml
@@ -6,7 +6,7 @@ description: |
 project_home: https://github.com/Starlitnightly/omicverse
 documentation_home: https://omicverse.readthedocs.io/
 publications:
-  - 10.1101/2023.06.06.543913
+  - 10.1038/s41467-024-50194-3
 install:
   pypi: omicverse
 primary_category: Multimodal

--- a/packages/panpipes/meta.yaml
+++ b/packages/panpipes/meta.yaml
@@ -5,7 +5,7 @@ project_home: https://github.com/DendrouLab/panpipes
 documentation_home: https://panpipes-pipelines.readthedocs.io/
 tutorials_home: https://panpipes-pipelines.readthedocs.io/page/tutorials/
 publications:
-  - 10.1101/2023.03.11.532085
+  - 10.1186/s13059-024-03322-7
 install:
   pypi: panpipes
 primary_category: Multimodal

--- a/packages/pertpy/meta.yaml
+++ b/packages/pertpy/meta.yaml
@@ -7,7 +7,7 @@ project_home: https://github.com/scverse/pertpy
 documentation_home: https://pertpy.readthedocs.io/
 tutorials_home: https://pertpy.readthedocs.io/page/tutorials.html
 publications:
-  - 10.1101/2024.08.04.606516
+  - 10.1038/s41592-025-02909-7
 install:
   pypi: pertpy
   conda: conda-forge::pertpy

--- a/packages/pyLemur/meta.yaml
+++ b/packages/pyLemur/meta.yaml
@@ -5,7 +5,7 @@ project_home: https://github.com/const-ae/pyLemur
 documentation_home: https://pyLemur.readthedocs.io/
 tutorials_home: https://pylemur.readthedocs.io/page/notebooks/Tutorial.html
 publications:
-  - 10.1101/2023.03.06.531268
+  - 10.1038/s41588-024-01996-0
 install:
   pypi: pyLemur
 primary_category: scRNA-seq

--- a/packages/scDataLoader/meta.yaml
+++ b/packages/scDataLoader/meta.yaml
@@ -6,7 +6,7 @@ description: |
 project_home: https://github.com/jkobject/scDataLoader
 documentation_home: https://www.jkobject.com/scDataLoader/
 publications:
-  - 10.1101/2024.07.29.605556
+  - 10.1038/s41467-025-58699-1
 install:
   pypi: scdataloader
 primary_category: Infrastructure

--- a/packages/scPRINT-2/meta.yaml
+++ b/packages/scPRINT-2/meta.yaml
@@ -4,7 +4,7 @@ description: |
 project_home: https://github.com/cantinilab/scPRINT-2
 documentation_home: https://cantinilab.github.io/scPRINT-2/
 publications:
-  - 10.64898/2025.12.11.693702v2
+  - 10.64898/2025.12.11.693702
 install:
   pypi: scprint2
 primary_category: scRNA-seq

--- a/packages/scPRINT/meta.yaml
+++ b/packages/scPRINT/meta.yaml
@@ -4,7 +4,7 @@ description: |
 project_home: https://github.com/cantinilab/scPRINT
 documentation_home: https://cantinilab.github.io/scPRINT/
 publications:
-  - 10.1101/2024.07.29.605556
+  - 10.1038/s41467-025-58699-1
 install:
   pypi: scprint
 primary_category: scRNA-seq

--- a/packages/scanpro/meta.yaml
+++ b/packages/scanpro/meta.yaml
@@ -4,7 +4,7 @@ project_home: https://github.com/loosolab/scanpro
 documentation_home: https://scanpro.readthedocs.io/
 tutorials_home: https://scanpro.readthedocs.io/page/proportion_analysis.html
 publications:
-  - 10.1101/2023.08.14.553234
+  - 10.1038/s41598-024-66381-7
 install:
   pypi: scanpro
 primary_category: scRNA-seq

--- a/packages/sctriangulate/meta.yaml
+++ b/packages/sctriangulate/meta.yaml
@@ -5,7 +5,7 @@ project_home: https://github.com/frankligy/scTriangulate
 documentation_home: https://sctriangulate.readthedocs.io/page/get_started.html
 tutorials_home: https://sctriangulate.readthedocs.io/page/tutorial.html
 publications:
-  - 10.1101/2021.10.16.464640
+  - 10.1038/s41467-023-36016-y
 install:
   pypi: sctriangulate
 primary_category: scRNA-seq


### PR DESCRIPTION
## Summary
- Many `publications` entries pointed at bioRxiv/medRxiv preprints whose peer-reviewed versions are now out — most notably pertpy in *Nature Methods*, CellOracle in *Nature*, and moscot in *Nature*.
- Each replacement was verified via the Crossref and bioRxiv APIs, cross-checking titles/authors between preprint and published record before swapping the DOI.
- `scPRINT`, `GRnnData`, `benGRN`, `scDataLoader` all cited the same scPRINT preprint; updated together to its *Nature Communications* DOI.
- `AESTETIK` had a duplicate entry — the second (preprint) DOI turned out to already be published under the DOI already listed first, so it was removed.
- `scPRINT-2` had a stray `v2` suffix on its (still-preprint) DOI; stripped it.
- Packages with preprints that don't yet have a published version (DRVI, cellxgene, clone2vec, kompot, scXpand, scxmatch, sincei, sobolev-alignment, spatial-eggplant, flashdeconv, some scvi-tools sub-papers, dandelion's VDJ preprint) were left unchanged.
