### PR TITLE
Derive version from the package index instead of maintaining it by hand

### DIFF
--- a/.github/workflows/make-json.yml
+++ b/.github/workflows/make-json.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Versions come from the package indexes, so rebuild daily to pick up new releases.
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ If none of the existing terms fit your package, add one to the enum in your pull
 
 `language` is the language you write in when using the package: `Python`, `R`, `Julia` or `Rust`.
 
+`version` is not something you set.
+It is read from PyPI, conda, CRAN or Bioconductor when the registry is built, and refreshed daily, so it always reflects the latest release.
+
 ## What are the requirements for an ecosystem package?
 
 For a package to become an approved ecosystem package, it must fulfill all mandatory requirements from the checklist below.

--- a/packages/AESTETIK/meta.yaml
+++ b/packages/AESTETIK/meta.yaml
@@ -21,7 +21,6 @@ tags:
   - deep learning
 license: MIT
 language: Python
-version: v0.3.1
 contact:
   - KalinNonchev
 test_command: pip install '.[test-all]' && pytest -m "not slow"

--- a/packages/CellAnnotator/meta.yaml
+++ b/packages/CellAnnotator/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - large language models
 license: MIT
 language: Python
-version: v0.1.3
 contact:
   - Marius1311
 test_command: pip install -e '.[test]' && pytest

--- a/packages/CellCharter/meta.yaml
+++ b/packages/CellCharter/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - probabilistic modeling
 license: BSD-3-Clause
 language: Python
-version: v0.3.1
 contact:
   - marcovarrone
 test_command: |

--- a/packages/CellMapper/meta.yaml
+++ b/packages/CellMapper/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - GPU acceleration
 license: MIT
 language: Python
-version: v0.1.2
 contact:
   - Marius1311
 test_command: pip install -e '.[test]' && pytest

--- a/packages/CellOracle/meta.yaml
+++ b/packages/CellOracle/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - perturbation
 license: Apache-2.0
 language: Python
-version: v0.10.12
 contact:
   - KenjiKamimoto-ac
   - sam-morris

--- a/packages/CellRank/meta.yaml
+++ b/packages/CellRank/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - deep learning
 license: BSD-3-Clause
 language: Python
-version: v1.5.1
 contact:
   - Marius1311
   - michalk8

--- a/packages/Cell_BLAST/meta.yaml
+++ b/packages/Cell_BLAST/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - cell-type annotation
 license: MIT
 language: Python
-version: v0.3.8
 contact:
   - Jeff1995
 test_command: |

--- a/packages/CellphoneDB/meta.yaml
+++ b/packages/CellphoneDB/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - cell-cell communication
 license: MIT
 language: Python
-version: v5.0.0
 contact:
   - chapuzzo
   - datasome

--- a/packages/Cirrocumulus/meta.yaml
+++ b/packages/Cirrocumulus/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - visualization
 license: BSD-3-Clause
 language: Python
-version: v1.1.41
 contact:
   - joshua-gould
   - yihming

--- a/packages/DOTools_py/meta.yaml
+++ b/packages/DOTools_py/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - visualization
 license: MIT
 language: Python
-version: v0.0.2
 contact:
   - davidrm-bio
 test_command: pip install "." && pytest

--- a/packages/DRVI/meta.yaml
+++ b/packages/DRVI/meta.yaml
@@ -20,7 +20,6 @@ tags:
   - probabilistic modeling
 license: BSD-3-Clause
 language: Python
-version: 0.2.0
 contact:
   - moinfar
 test_command: uvx hatch run pytest

--- a/packages/DoubletDetection/meta.yaml
+++ b/packages/DoubletDetection/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - quality control
 license: MIT
 language: Python
-version: v4.2
 contact:
   - adamgayoso
   - JonathanShor

--- a/packages/GPTBioInsightor/meta.yaml
+++ b/packages/GPTBioInsightor/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - large language models
 license: BSD-3-Clause
 language: Python
-version: v0.3.0
 contact:
   - huangsh
 test_command: pip install "." && pytest

--- a/packages/GRnnData/meta.yaml
+++ b/packages/GRnnData/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - file formats
 license: MIT
 language: Python
-version: v1.1.4
 contact:
   - jkobject
 test_command: pip install . && make test

--- a/packages/LazySlide/meta.yaml
+++ b/packages/LazySlide/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - deep learning
 license: MIT
 language: Python
-version: v0.3.0
 contact:
   - Mr-Milk
   - eabila

--- a/packages/Mowgli/meta.yaml
+++ b/packages/Mowgli/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - optimal transport
 license: GPL-3.0-only
 language: Python
-version: v0.2.0
 contact:
   - gjhuizing
 test_command: pip install . && pytest

--- a/packages/Multivelo/meta.yaml
+++ b/packages/Multivelo/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - RNA velocity
 license: BSD-3-Clause
 language: Python
-version: 0.1.3
 contact:
   - jw156605
   - danielee0707

--- a/packages/PEAKQC/meta.yaml
+++ b/packages/PEAKQC/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - quality control
 license: MIT
 language: Python
-version: 0.1.3
 contact:
   - mlooso
 test_command: pip install . && pytest

--- a/packages/PILOT/meta.yaml
+++ b/packages/PILOT/meta.yaml
@@ -23,7 +23,6 @@ tags:
   - optimal transport
 license: MIT
 language: Python
-version: v2.0.6
 contact:
   - mehdijoodaki
   - minashaigan

--- a/packages/ParTIpy/meta.yaml
+++ b/packages/ParTIpy/meta.yaml
@@ -11,7 +11,6 @@ language: Python
 primary_category: scRNA-seq
 tags:
   - dimensionality reduction
-version: v0.0.04
 contact:
   - psl-schaefer
   - leotenshii

--- a/packages/PathML/meta.yaml
+++ b/packages/PathML/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - imaging
 license: GPL-2.0-only
 language: Python
-version: v2.1.0
 contact:
   - jacob-rosenthal
   - ryanccarelli

--- a/packages/PyDESeq2/meta.yaml
+++ b/packages/PyDESeq2/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - differential expression
 publications:
   - 10.1101/2022.12.14.520412
-version: v0.3.0
 contact:
   - BorisMuzellec
   - maikia

--- a/packages/Rectangle/meta.yaml
+++ b/packages/Rectangle/meta.yaml
@@ -13,7 +13,6 @@ primary_category: bulk RNA-seq
 tags:
   - bulk RNA-seq
   - deconvolution
-version: v0.1.6
 contact:
   - bernheder
 test_command: |

--- a/packages/SC2Spa/meta.yaml
+++ b/packages/SC2Spa/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - deep learning
 license: BSD-3-Clause
 language: Python
-version: v1.2
 contact:
   - linbuliao
 test_command: pip install "." && pytest

--- a/packages/SCALEX/meta.yaml
+++ b/packages/SCALEX/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - data integration
 license: MIT
 language: Python
-version: v1.0.3
 contact:
   - jsxlei
 test_command: pip install ".[test]" && pytest

--- a/packages/STMiner/meta.yaml
+++ b/packages/STMiner/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - optimal transport
 license: GPL-3.0-or-later
 language: Python
-version: v1.1.0
 contact:
   - PSSUN
 test_command: pip install "." && pytest

--- a/packages/SnapATAC2/meta.yaml
+++ b/packages/SnapATAC2/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - epigenomics
 license: MIT
 language: Python
-version: 2.5.0
 contact:
   - kaizhang
 logo: logo.svg

--- a/packages/TreeData/meta.yaml
+++ b/packages/TreeData/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - data structures
 license: BSD-3-Clause
 language: Python
-version: v0.2.2
 contact:
   - colganwi
 test_command: pip install ".[test]" && pytest

--- a/packages/alphapepttools/meta.yaml
+++ b/packages/alphapepttools/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - file formats
 license: Apache-2.0
 language: Python
-version: 0.2.0
 contact:
   - vbrennsteiner
   - lucas-diedrich

--- a/packages/anndata-for-R/meta.yaml
+++ b/packages/anndata-for-R/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - interoperability
 license: MIT
 language: R
-version: 0.7.5.5
 contact:
   - rcannood
 category: ecosystem

--- a/packages/anndata/meta.yaml
+++ b/packages/anndata/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - data structures
 license: BSD-3-Clause
 language: Python
-version: 0.12.4
 contact:
   - flying-sheep
   - ilan-gold

--- a/packages/anndataR/meta.yaml
+++ b/packages/anndataR/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - interoperability
 publications:
   - 10.1101/2025.08.18.669052 # bioRxiv preprint
-version: 1.0.0
 contact:
   - lazappi
   - rcannood

--- a/packages/annsel/meta.yaml
+++ b/packages/annsel/meta.yaml
@@ -9,7 +9,6 @@ install:
   pypi: annsel
 license: MIT
 language: Python
-version: v0.0.8
 contact:
   - srivarra
 primary_category: Data structures

--- a/packages/benGRN/meta.yaml
+++ b/packages/benGRN/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - benchmarking
 license: MIT
 language: Python
-version: v1.2.1
 contact:
   - jkobject
 test_command: pip install . && make test

--- a/packages/bento-tools/meta.yaml
+++ b/packages/bento-tools/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - segmentation
 license: BSD-2-Clause
 language: Python
-version: v1.0.1
 contact:
   - ckmah
   - noor01

--- a/packages/biolord/meta.yaml
+++ b/packages/biolord/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - deep learning
 license: BSD-3-Clause
 language: Python
-version: v0.0.1
 contact:
   - zoepiran
 test_command: |

--- a/packages/cell2location/meta.yaml
+++ b/packages/cell2location/meta.yaml
@@ -19,7 +19,6 @@ tags:
   - probabilistic modeling
 license: Apache-2.0
 language: Python
-version: v0.1
 contact:
   - vitkl
   - yozhikoff

--- a/packages/cellxgene/meta.yaml
+++ b/packages/cellxgene/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - visualization
 license: MIT
 language: Python
-version: 1.1.1
 contact:
   - csweaver
   - bkmartinjr

--- a/packages/clone2vec/meta.yaml
+++ b/packages/clone2vec/meta.yaml
@@ -13,7 +13,6 @@ license: MIT
 language: Python
 publications:
   - 10.1101/2024.11.15.623687
-version: v0.1.0
 contact:
   - serjisa
 test_command: |

--- a/packages/cookiecutter-scverse/meta.yaml
+++ b/packages/cookiecutter-scverse/meta.yaml
@@ -8,7 +8,6 @@ tags:
   - documentation
 license: BSD-3-Clause
 language: Python
-version: 0.6.0
 contact:
   - grst
   - flying-sheep

--- a/packages/dandelion/meta.yaml
+++ b/packages/dandelion/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - immune receptor
 license: AGPL-3.0-or-later
 language: Python
-version: v0.3.0
 contact:
   - zktuong
   - ktpolanski

--- a/packages/decoupler/meta.yaml
+++ b/packages/decoupler/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - functional analysis
 license: BSD-3-Clause
 language: Python
-version: 2.1.1
 contact:
   - PauBadiaM
 logo: logo.svg

--- a/packages/delnx/meta.yaml
+++ b/packages/delnx/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - differential expression
 license: MIT
 language: Python
-version: v0.2.3
 contact:
   - joschif
   - adaml9

--- a/packages/dvp-io/meta.yaml
+++ b/packages/dvp-io/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - file formats
 license: Apache-2.0
 language: Python
-version: 0.5.1
 contact:
   - lucas-diedrich
 logo: logo.svg

--- a/packages/dynamo-release/meta.yaml
+++ b/packages/dynamo-release/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - RNA velocity
 license: BSD-3-Clause
 language: Python
-version: v1.1.0
 contact:
   - Xiaojieqiu
   - dummyindex

--- a/packages/epiScanpy/meta.yaml
+++ b/packages/epiScanpy/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - epigenomics
 license: BSD-3-Clause
 language: Python
-version: v0.3.2
 contact:
   - DaneseAnna
   - mrichter23

--- a/packages/eschr/meta.yaml
+++ b/packages/eschr/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - probabilistic modeling
 license: "MIT"
 language: Python
-version: v1.0.1
 contact:
   - smgoggin10
 test_command: pip install ".[test]" && pytest

--- a/packages/favapy/meta.yaml
+++ b/packages/favapy/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - deep learning
 license: MIT
 language: Python
-version: v0.3.9.4
 contact:
   - mikelkou
 category: ecosystem

--- a/packages/flashdeconv/meta.yaml
+++ b/packages/flashdeconv/meta.yaml
@@ -19,7 +19,6 @@ tags:
   - deconvolution
 license: BSD-3-Clause
 language: Python
-version: v0.1
 contact:
   - cafferychen777
 test_command: |

--- a/packages/flowsom/meta.yaml
+++ b/packages/flowsom/meta.yaml
@@ -20,7 +20,6 @@ tags:
   - clustering
 license: GPL-3.0-only
 language: Python
-version: v0.0.1
 contact:
   - artuurC
   - berombau

--- a/packages/grassp/meta.yaml
+++ b/packages/grassp/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - proteomics
 license: BSD-3-Clause
 language: Python
-version: v0.1.0
 contact:
   - mffrank
   - duopeng

--- a/packages/gssnng/meta.yaml
+++ b/packages/gssnng/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - functional analysis
 license: MIT
 language: Python
-version: v0.4.2
 contact:
   - gibbsdavidl
   - redst4r

--- a/packages/hotspot/meta.yaml
+++ b/packages/hotspot/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - gene regulatory networks
 license: BSD-3-Clause
 language: Python
-version: v1.1.1
 contact:
   - deto
   - adamgayoso

--- a/packages/illico/meta.yaml
+++ b/packages/illico/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - differential expression
 license: Apache-2.0
 language: Python
-version: 0.1.1
 contact:
   - remydubois
 test_command: |

--- a/packages/infercnvpy/meta.yaml
+++ b/packages/infercnvpy/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - copy number variation
 license: BSD-3-Clause
 language: Python
-version: v0.3.0
 contact:
   - grst
 test_command: |

--- a/packages/kompot/meta.yaml
+++ b/packages/kompot/meta.yaml
@@ -21,7 +21,6 @@ tags:
   - probabilistic modeling
 license: GPL-3.0-or-later
 language: Python
-version: v0.6.1
 contact:
   - katosh
   - ManuSetty

--- a/packages/liana/meta.yaml
+++ b/packages/liana/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - cell-cell communication
 license: GPL-3.0-only
 language: Python
-version: v1.0.0a1
 contact:
   - dbdimitrov
 test_command: |

--- a/packages/maxspin/meta.yaml
+++ b/packages/maxspin/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - spatially variable genes
 license: MIT
 language: Python
-version: v0.1.1
 contact:
   - dcjones
 test_command: pip install "." && pytest

--- a/packages/moscot/meta.yaml
+++ b/packages/moscot/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - optimal transport
 license: BSD-3-Clause
 language: Python
-version: v0.4.0
 contact:
   - MUCDK
   - giovp

--- a/packages/mudata/meta.yaml
+++ b/packages/mudata/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - data structures
 license: BSD-3-Clause
 language: Python
-version: 0.3.2
 contact:
   - gtca
   - ilia-kats

--- a/packages/muon/meta.yaml
+++ b/packages/muon/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - data integration
 license: BSD-3-Clause
 language: Python
-version: 0.1.7
 contact:
   - gtca
 logo: logo.svg

--- a/packages/nichepca/meta.yaml
+++ b/packages/nichepca/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - clustering
 license: MIT
 language: Python
-version: v0.0.3
 contact:
   - dschaub95
 test_command: |

--- a/packages/novae/meta.yaml
+++ b/packages/novae/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - deep learning
 license: BSD-3-Clause
 language: Python
-version: v0.2.1
 contact:
   - quentinblampey
 test_command: pip install ".[dev]" && pytest

--- a/packages/omicverse/meta.yaml
+++ b/packages/omicverse/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - multimodal
 license: GPL-3.0-only
 language: Python
-version: v1.4.12
 contact:
   - Starlitnightly
   - DBinary

--- a/packages/palantir/meta.yaml
+++ b/packages/palantir/meta.yaml
@@ -20,7 +20,6 @@ tags:
   - trajectory inference
 license: GPL-2.0-or-later
 language: Python
-version: v1.3.3
 contact:
   - ManuSetty
   - katosh

--- a/packages/panpipes/meta.yaml
+++ b/packages/panpipes/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - pipeline
 license: BSD-3-Clause
 language: Python
-version: v0.5.0
 contact:
   - bio-la
   - crichgriffin

--- a/packages/pcdl/meta.yaml
+++ b/packages/pcdl/meta.yaml
@@ -11,7 +11,6 @@ primary_category: Infrastructure
 tags:
   - file formats
 #publications:
-version: v4.0.4
 category: ecosystem
 contact:
   - ASundus

--- a/packages/pegasus/meta.yaml
+++ b/packages/pegasus/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - clustering
 license: BSD-3-Clause
 language: Python
-version: v1.7.1
 contact:
   - yihming
   - bli25

--- a/packages/pertpy/meta.yaml
+++ b/packages/pertpy/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - perturbation
 license: MIT
 language: Python
-version: 1.0.3
 contact:
   - Zethson
 logo: logo.svg

--- a/packages/popV/meta.yaml
+++ b/packages/popV/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - cell-type annotation
 license: MIT
 language: Python
-version: v0.5.2
 contact:
   - canergen
 test_command: pip install -e '.[test]' && pytest

--- a/packages/pyCrossTalkeR/meta.yaml
+++ b/packages/pyCrossTalkeR/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - cell-cell communication
 license: MIT
 language: Python
-version: v2.1.0
 contact:
   - jsnagai
   - ruthvik07

--- a/packages/pyLemur/meta.yaml
+++ b/packages/pyLemur/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - differential expression
 license: MIT
 language: Python
-version: v0.1.0
 contact:
   - const-ae
 test_command: pip install -e '.[dev]' && pytest

--- a/packages/pySCENIC/meta.yaml
+++ b/packages/pySCENIC/meta.yaml
@@ -19,7 +19,6 @@ tags:
   - clustering
 license: GPL-3.0-only
 language: Python
-version: v0.12.0
 contact:
   - bramvds
   - cflerin

--- a/packages/pyUCell/meta.yaml
+++ b/packages/pyUCell/meta.yaml
@@ -18,7 +18,6 @@ tags:
   - functional analysis
 license: MIT
 language: Python
-version: v0.3.0
 contact:
   - mass-a
   - sjcarmona

--- a/packages/pycea/meta.yaml
+++ b/packages/pycea/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - data structures
 license: BSD-3-Clause
 language: Python
-version: v0.1.0
 contact:
   - colganwi
 test_command: pip install ".[test]" && pytest

--- a/packages/pychromVAR/meta.yaml
+++ b/packages/pychromVAR/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - gene regulatory networks
 license: MIT
 language: Python
-version: v0.0.3
 contact:
   - lzj1769
 test_command: |

--- a/packages/pytximport/meta.yaml
+++ b/packages/pytximport/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - file formats
 license: GPL-3.0-only
 language: Python
-version: v0.2.0
 contact:
   - maltekuehl
 test_command: |

--- a/packages/rapids-singlecell/meta.yaml
+++ b/packages/rapids-singlecell/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - GPU acceleration
 license: MIT
 language: Python
-version: 0.13.3
 contact:
   - Intron7
 logo: logo.svg

--- a/packages/scCellFie/meta.yaml
+++ b/packages/scCellFie/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - cell-cell communication
 license: MIT
 language: Python
-version: v0.4.5
 contact:
   - earmingol
 test_command: |

--- a/packages/scDataLoader/meta.yaml
+++ b/packages/scDataLoader/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - file formats
 license: MIT
 language: Python
-version: v1.2.2
 contact:
   - jkobject
 test_command: pip install . && make test

--- a/packages/scFates/meta.yaml
+++ b/packages/scFates/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - pseudotime
 license: BSD-3-Clause
 language: Python
-version: v1.0.0
 contact:
   - LouisFaure
 test_command: |

--- a/packages/scGen/meta.yaml
+++ b/packages/scGen/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - perturbation
 license: GPL-3.0-only
 language: Python
-version: v2.1.0
 contact:
   - M0hammadL
   - adamgayoso

--- a/packages/scPRINT-2/meta.yaml
+++ b/packages/scPRINT-2/meta.yaml
@@ -20,7 +20,6 @@ tags:
   - foundation model
 license: GPL-3.0-or-later
 language: Python
-version: v1.0.0
 contact:
   - jkobject
 test_command: pip install . && make test

--- a/packages/scPRINT/meta.yaml
+++ b/packages/scPRINT/meta.yaml
@@ -18,7 +18,6 @@ tags:
   - foundation model
 license: MIT
 language: Python
-version: v1.6.2
 contact:
   - jkobject
 test_command: pip install . && make test

--- a/packages/scXpand/meta.yaml
+++ b/packages/scXpand/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - deep learning
 license: MIT
 language: Python
-version: v0.4.3
 contact:
   - ronamit
   - ofirshorer

--- a/packages/scanpro/meta.yaml
+++ b/packages/scanpro/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - compositional analysis
 license: MIT
 language: Python
-version: 0.2.0
 contact:
   - yalayoubi
   - mlooso

--- a/packages/scanpy/meta.yaml
+++ b/packages/scanpy/meta.yaml
@@ -20,7 +20,6 @@ tags:
   - visualization
 license: BSD-3-Clause
 language: Python
-version: 1.11.5
 contact:
   - flying-sheep
   - ilan-gold

--- a/packages/schist/meta.yaml
+++ b/packages/schist/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - clustering
 publications:
   - 10.1186/s12859-021-04489-7
-version: v0.8.1
 contact:
   - dawe
   - leomorelli

--- a/packages/scib-rapids/meta.yaml
+++ b/packages/scib-rapids/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - GPU acceleration
 license: BSD-3-Clause
 language: Python
-version: 0.1.0
 contact:
   - maarten-devries
 category: ecosystem

--- a/packages/scib/meta.yaml
+++ b/packages/scib/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - benchmarking
 license: MIT
 language: Python
-version: v1.0.5
 contact:
   - mumichae
   - LuckyMD

--- a/packages/scirpy/meta.yaml
+++ b/packages/scirpy/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - immune receptor
 license: BSD-3-Clause
 language: Python
-version: 0.22.3
 contact:
   - grst
 logo: logo.svg

--- a/packages/scmcp/meta.yaml
+++ b/packages/scmcp/meta.yaml
@@ -9,7 +9,6 @@ tags:
   - large language models
 license: BSD-3-Clause
 language: Python
-version: v0.2.2
 contact:
   - huangsh
 test_command: uv run --no-sync pytest

--- a/packages/sctriangulate/meta.yaml
+++ b/packages/sctriangulate/meta.yaml
@@ -13,7 +13,6 @@ tags:
   - clustering
 license: MIT
 language: Python
-version: v0.12.0
 contact:
   - frankligy
 test_command: pip install "." && pytest

--- a/packages/scvelo/meta.yaml
+++ b/packages/scvelo/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - RNA velocity
 license: BSD-3-Clause
 language: Python
-version: v0.2.5
 contact:
   - WeilerP
   - VolkerBergen

--- a/packages/scvi-tools/meta.yaml
+++ b/packages/scvi-tools/meta.yaml
@@ -38,7 +38,6 @@ tags:
   - probabilistic modeling
 license: BSD-3-Clause
 language: Python
-version: 1.4.0.post1
 contact:
   - ori-kron-wis
   - canergen

--- a/packages/scxmatch/meta.yaml
+++ b/packages/scxmatch/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - probabilistic modeling
 license: MIT
 language: Python
-version: v0.1.0
 contact:
   - annmoel
   - dbblumenthal

--- a/packages/scyan/meta.yaml
+++ b/packages/scyan/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - cell-type annotation
 license: BSD-3-Clause
 language: Python
-version: v1.5.0
 contact:
   - quentinblampey
 test_command: pip install ".[dev]" && pytest

--- a/packages/sift-sc/meta.yaml
+++ b/packages/sift-sc/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - preprocessing
 license: BSD-3-Clause
 language: Python
-version: v0.1.0
 contact:
   - zoepiran
 test_command: |

--- a/packages/sincei/meta.yaml
+++ b/packages/sincei/meta.yaml
@@ -22,7 +22,6 @@ tags:
   - file formats
 license: MIT
 language: Python
-version: v0.5.1
 authors:
   - vivekbhr
   - saroudant

--- a/packages/sobolev-alignment/meta.yaml
+++ b/packages/sobolev-alignment/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - probabilistic modeling
 license: MIT
 language: Python
-version: 1.0.0
 contact:
   - saroudant
 test_command: |

--- a/packages/sopa/meta.yaml
+++ b/packages/sopa/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - pipeline
 license: BSD-3-Clause
 language: Python
-version: v1.0.0
 contact:
   - quentinblampey
 test_command: pip install ".[dev,cellpose]" && pytest

--- a/packages/spatial-eggplant/meta.yaml
+++ b/packages/spatial-eggplant/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - data integration
 license: MIT
 language: Python
-version: v0.2.3
 contact:
   - almaan
 test_command: pip install "." && pytest

--- a/packages/spatialdata/meta.yaml
+++ b/packages/spatialdata/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - file formats
 license: BSD-3-Clause
 language: Python
-version: 0.5.0
 contact:
   - LucaMarconato
   - melonora

--- a/packages/spatialproteomics/meta.yaml
+++ b/packages/spatialproteomics/meta.yaml
@@ -16,7 +16,6 @@ tags:
   - pipeline
 license: MIT
 language: Python
-version: v0.7.0
 contact:
   - MeyerBender
   - sagar87

--- a/packages/spatiomic/meta.yaml
+++ b/packages/spatiomic/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - segmentation
 license: GPL-3.0-only
 language: Python
-version: v0.5.0
 contact:
   - maltekuehl
 test_command: uv run pytest -m "not gpu"

--- a/packages/squidpy/meta.yaml
+++ b/packages/squidpy/meta.yaml
@@ -18,7 +18,6 @@ tags:
   - imaging
 license: BSD-3-Clause
 language: Python
-version: 1.6.5
 contact:
   - giovp
   - timtreis

--- a/packages/symphonypy/meta.yaml
+++ b/packages/symphonypy/meta.yaml
@@ -11,7 +11,6 @@ tags:
   - cell-type annotation
 license: GPL-3.0-only
 language: Python
-version: v0.2.1
 contact:
   - serjisa
   - potulabe

--- a/packages/tangram/meta.yaml
+++ b/packages/tangram/meta.yaml
@@ -14,7 +14,6 @@ tags:
   - deconvolution
 license: BSD-3-Clause
 language: Python
-version: v1.0.3
 contact:
   - ziqlu0722
   - lewlin

--- a/packages/tau-community-detection/meta.yaml
+++ b/packages/tau-community-detection/meta.yaml
@@ -15,7 +15,6 @@ tags:
   - clustering
 publications:
   - 10.1093/pnasnexus/pgad180
-version: 1.4.7
 contact:
   - HillelCharbit
 category: ecosystem

--- a/packages/vitessce/meta.yaml
+++ b/packages/vitessce/meta.yaml
@@ -17,7 +17,6 @@ tags:
   - visualization
 license: MIT
 language: Python
-version: v3.5.7
 contact:
   - keller-mark
   - mccalluc

--- a/packages/wsidata/meta.yaml
+++ b/packages/wsidata/meta.yaml
@@ -12,7 +12,6 @@ tags:
   - file formats
 license: MIT
 language: Python
-version: v0.3.0
 contact:
   - Mr-Milk
   - eabila

--- a/packages/zellkonverter/meta.yaml
+++ b/packages/zellkonverter/meta.yaml
@@ -14,7 +14,6 @@ primary_category: Data structures
 tags:
   - data structures
   - interoperability
-version: 1.20.0
 contact:
   - lazappi
 logo: logo.svg

--- a/scripts/src/ecosystem_scripts/schema.json
+++ b/scripts/src/ecosystem_scripts/schema.json
@@ -274,8 +274,9 @@
             }
         },
         "version": {
-            "description": "The version of the package at the point when this entry was created or updated",
-            "type": "string"
+            "description": "Latest released version, derived from the package index at build time. Do not set this in meta.yaml; it is overwritten.",
+            "type": "string",
+            "readOnly": true
         },
         "contact": {
             "description": "Point of contact for this package. Does not need to be the full list of maintainers. Entries must be Github user IDs.",
@@ -327,6 +328,6 @@
         }
     },
     "then": {
-        "required": ["install", "version"]
+        "required": ["install"]
     }
 }

--- a/scripts/src/ecosystem_scripts/validate_registry.py
+++ b/scripts/src/ecosystem_scripts/validate_registry.py
@@ -148,10 +148,12 @@ class GitHubUserValidator(HTTPValidator):
 
 @dataclass
 class PyPIValidator(HTTPValidator):
-    """Validate PyPI package names against the PyPI API."""
+    """Validate PyPI package names against the PyPI API and record the released version."""
+
+    versions: dict[str, str] = field(default_factory=dict)
 
     async def __call__(self, package_name: str, context: str) -> None:
-        """Validate that a PyPI package exists.
+        """Validate that a PyPI package exists and remember its latest version.
 
         Parameters
         ----------
@@ -160,11 +162,11 @@ class PyPIValidator(HTTPValidator):
         context
             Context information for error messages (e.g., file being validated)
         """
-        if package_name in self.validated:
+        if package_name in self.versions:
             return
 
         try:
-            response = await self.client.head(f"https://pypi.org/pypi/{package_name}/json")
+            response = await self.client.get(f"https://pypi.org/pypi/{package_name}/json")
         except Exception as e:
             msg = f"{context}: Failed to validate PyPI package {package_name!r}: {e}"
             raise ValidationError(msg) from e
@@ -176,13 +178,15 @@ class PyPIValidator(HTTPValidator):
             msg = f"{context}: Failed to validate PyPI package {package_name!r} (error {response.status_code})"
             raise ValidationError(msg)
 
-        self.validated.add(package_name)
-        log.info(f"Validated PyPI package for {context}: {package_name}")
+        self.versions[package_name] = str(response.json()["info"]["version"])
+        log.info(f"Validated PyPI package for {context}: {package_name} {self.versions[package_name]}")
 
 
 @dataclass
 class CondaValidator(HTTPValidator):
-    """Validate Conda package identifiers using the Anaconda API."""
+    """Validate Conda package identifiers using the Anaconda API and record the released version."""
+
+    versions: dict[str, str] = field(default_factory=dict)
 
     async def __call__(self, package_spec: str, context: str) -> None:
         """Validate that a Conda package exists.
@@ -194,7 +198,7 @@ class CondaValidator(HTTPValidator):
         context
             Context information for error messages (e.g., file being validated)
         """
-        if package_spec in self.validated:
+        if package_spec in self.versions:
             return
 
         # Parse channel and package name
@@ -206,7 +210,7 @@ class CondaValidator(HTTPValidator):
 
         # Check package exists on the channel
         try:
-            response = await self.client.head(f"https://api.anaconda.org/package/{channel}/{package_name}")
+            response = await self.client.get(f"https://api.anaconda.org/package/{channel}/{package_name}")
         except Exception as e:
             msg = f"{context}: Failed to validate Conda package '{package_spec}': {e}"
             raise ValidationError(msg) from e
@@ -218,13 +222,15 @@ class CondaValidator(HTTPValidator):
             msg = f"{context}: Failed to validate Conda package '{package_spec}' (error {response.status_code})"
             raise ValidationError(msg)
 
-        self.validated.add(package_spec)
-        log.info(f"Validated Conda package for {context}: {package_spec}")
+        self.versions[package_spec] = str(response.json()["latest_version"])
+        log.info(f"Validated Conda package for {context}: {package_spec} {self.versions[package_spec]}")
 
 
 @dataclass
 class CRANValidator(HTTPValidator):
-    """Validate CRAN package names using the CRAN API."""
+    """Validate CRAN package names using the CRAN API and record the released version."""
+
+    versions: dict[str, str] = field(default_factory=dict)
 
     async def __call__(self, package_name: str, context: str) -> None:
         """Validate that a CRAN package exists.
@@ -236,12 +242,12 @@ class CRANValidator(HTTPValidator):
         context
             Context information for error messages (e.g., file being validated)
         """
-        if package_name in self.validated:
+        if package_name in self.versions:
             return
 
         # CRAN packages can be checked via the packages database
         try:
-            response = await self.client.head(f"https://crandb.r-pkg.org/{package_name}")
+            response = await self.client.get(f"https://crandb.r-pkg.org/{package_name}")
         except Exception as e:
             msg = f"{context}: Failed to validate CRAN package '{package_name}': {e}"
             raise ValidationError(msg) from e
@@ -253,16 +259,47 @@ class CRANValidator(HTTPValidator):
             msg = f"{context}: Failed to validate CRAN package '{package_name}' (error {response.status_code})"
             raise ValidationError(msg)
 
-        self.validated.add(package_name)
-        log.info(f"Validated CRAN package for {context}: {package_name}")
+        self.versions[package_name] = str(response.json()["Version"])
+        log.info(f"Validated CRAN package for {context}: {package_name} {self.versions[package_name]}")
+
+
+BIOC_VIEWS_URL = "https://bioconductor.org/packages/release/bioc/VIEWS"
 
 
 @dataclass
 class BioconductorValidator(HTTPValidator):
-    """Validate Bioconductor package names using the Bioconductor API."""
+    """Validate Bioconductor package names and record the released version.
+
+    Bioconductor publishes every package and version in a single DCF file, so one request
+    covers the whole registry.
+    """
+
+    versions: dict[str, str] = field(default_factory=dict)
+    _fetched: asyncio.Event = field(default_factory=asyncio.Event)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def _load_views(self, context: str) -> None:
+        async with self._lock:
+            if self._fetched.is_set():
+                return
+            try:
+                response = await self.client.get(BIOC_VIEWS_URL)
+                response.raise_for_status()
+            except Exception as e:
+                msg = f"{context}: Failed to fetch the Bioconductor package list: {e}"
+                raise ValidationError(msg) from e
+
+            name: str | None = None
+            for line in response.text.splitlines():
+                if line.startswith("Package: "):
+                    name = line.removeprefix("Package: ").strip()
+                elif line.startswith("Version: ") and name:
+                    self.versions[name] = line.removeprefix("Version: ").strip()
+                    name = None
+            self._fetched.set()
 
     async def __call__(self, package_name: str, context: str) -> None:
-        """Validate that a Bioconductor package exists.
+        """Validate that a Bioconductor package exists and remember its latest version.
 
         Parameters
         ----------
@@ -271,25 +308,13 @@ class BioconductorValidator(HTTPValidator):
         context
             Context information for error messages (e.g., file being validated)
         """
-        if package_name in self.validated:
-            return
+        await self._load_views(context)
 
-        # Bioconductor packages can be checked via their web API
-        try:
-            response = await self.client.head(f"https://bioconductor.org/packages/{package_name}/")
-        except Exception as e:
-            msg = f"{context}: Failed to validate Bioconductor package '{package_name}': {e}"
-            raise ValidationError(msg) from e
-
-        if response.status_code == httpx.codes.NOT_FOUND:
+        if package_name not in self.versions:
             msg = f"{context}: Bioconductor package '{package_name}' does not exist"
             raise ValidationError(msg)
-        if response.status_code != httpx.codes.OK:
-            msg = f"{context}: Failed to validate Bioconductor package '{package_name}' (error {response.status_code})"
-            raise ValidationError(msg)
 
-        self.validated.add(package_name)
-        log.info(f"Validated Bioconductor package for {context}: {package_name}")
+        log.info(f"Validated Bioconductor package for {context}: {package_name} {self.versions[package_name]}")
 
 
 def check_image(img_path: Path) -> None:
@@ -408,7 +433,25 @@ class Checker:
                 log.error(e)
                 pkg_errors.append(e)
 
+        # The registry does not carry a version: whatever the package index says is the truth.
+        if version := self.released_version(tmp_meta):
+            tmp_meta["version"] = version
+
         return pkg_id, tmp_meta, pkg_errors
+
+    def released_version(self, tmp_meta: ScverseEcosystemPackages) -> str | None:
+        """Return the version the package's index reports, preferring the primary install target."""
+        if not (install := tmp_meta.get("install")):
+            return None
+        if name := install.get("pypi"):
+            return self.check_pypi.versions.get(name)
+        if spec := install.get("conda"):
+            return self.check_conda.versions.get(spec)
+        if name := install.get("cran"):
+            return self.check_cran.versions.get(name)
+        if name := install.get("bioconductor"):
+            return self.check_bioc.versions.get(name)
+        return None
 
     def http_checks(self, pkg_id: str, tmp_meta: ScverseEcosystemPackages) -> Generator[Awaitable[None]]:
         # Check and register all links

--- a/scripts/src/ecosystem_scripts/validate_registry.py
+++ b/scripts/src/ecosystem_scripts/validate_registry.py
@@ -264,39 +264,14 @@ class CRANValidator(HTTPValidator):
 
 
 BIOC_VIEWS_URL = "https://bioconductor.org/packages/release/bioc/VIEWS"
+RE_BIOC_VERSION = re.compile(r"^Package: (\S+)\nVersion: (\S+)$", re.MULTILINE)
 
 
 @dataclass
 class BioconductorValidator(HTTPValidator):
-    """Validate Bioconductor package names and record the released version.
-
-    Bioconductor publishes every package and version in a single DCF file, so one request
-    covers the whole registry.
-    """
+    """Validate Bioconductor package names and record the released version."""
 
     versions: dict[str, str] = field(default_factory=dict)
-    _fetched: asyncio.Event = field(default_factory=asyncio.Event)
-    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-
-    async def _load_views(self, context: str) -> None:
-        async with self._lock:
-            if self._fetched.is_set():
-                return
-            try:
-                response = await self.client.get(BIOC_VIEWS_URL)
-                response.raise_for_status()
-            except Exception as e:
-                msg = f"{context}: Failed to fetch the Bioconductor package list: {e}"
-                raise ValidationError(msg) from e
-
-            name: str | None = None
-            for line in response.text.splitlines():
-                if line.startswith("Package: "):
-                    name = line.removeprefix("Package: ").strip()
-                elif line.startswith("Version: ") and name:
-                    self.versions[name] = line.removeprefix("Version: ").strip()
-                    name = None
-            self._fetched.set()
 
     async def __call__(self, package_name: str, context: str) -> None:
         """Validate that a Bioconductor package exists and remember its latest version.
@@ -308,7 +283,14 @@ class BioconductorValidator(HTTPValidator):
         context
             Context information for error messages (e.g., file being validated)
         """
-        await self._load_views(context)
+        if not self.versions:
+            # Bioconductor publishes every package and version in one DCF file, so this is one request for all of them.
+            try:
+                response = await self.client.get(BIOC_VIEWS_URL)
+            except Exception as e:
+                msg = f"{context}: Failed to fetch the Bioconductor package list: {e}"
+                raise ValidationError(msg) from e
+            self.versions = dict(RE_BIOC_VERSION.findall(response.text))
 
         if package_name not in self.versions:
             msg = f"{context}: Bioconductor package '{package_name}' does not exist"

--- a/scripts/src/ecosystem_scripts/validate_registry.py
+++ b/scripts/src/ecosystem_scripts/validate_registry.py
@@ -287,9 +287,12 @@ class BioconductorValidator(HTTPValidator):
             # Bioconductor publishes every package and version in one DCF file, so this is one request for all of them.
             try:
                 response = await self.client.get(BIOC_VIEWS_URL)
-            except Exception as e:
+            except httpx.HTTPError as e:
                 msg = f"{context}: Failed to fetch the Bioconductor package list: {e}"
                 raise ValidationError(msg) from e
+            if response.status_code != httpx.codes.OK:
+                msg = f"{context}: Failed to fetch the Bioconductor package list (error {response.status_code})"
+                raise ValidationError(msg)
             self.versions = dict(RE_BIOC_VERSION.findall(response.text))
 
         if package_name not in self.versions:
@@ -415,7 +418,6 @@ class Checker:
                 log.error(e)
                 pkg_errors.append(e)
 
-        # The registry does not carry a version: whatever the package index says is the truth.
         if version := self.released_version(tmp_meta):
             tmp_meta["version"] = version
 


### PR DESCRIPTION
`version` in `meta.yaml` is written once and rarely updated. Of the 105 packages installable from PyPI, **10 match the index and 95 do not**. Several are a major version behind.

The website renders that field very soon. It's useful to judge which tools are production ready (yes semver is complicated) and which ones are not.

- `version` is removed from all 112 `meta.yaml` files and marked `readOnly` in the schema
- it is no longer required alongside `install`
- `Make JSON` also runs daily, so a new release reaches the website without anyone pushing