### PR TITLE
Add pbcheck

### DIFF
--- a/packages/pbcheck/meta.yaml
+++ b/packages/pbcheck/meta.yaml
@@ -1,0 +1,27 @@
+name: pbcheck
+blurb: Pseudoreplication audit for single-cell DE designs
+description: |
+  pbcheck audits one single-cell RNA-seq differential-expression design for pseudoreplication.
+  Given an .h5ad file, the donor and condition columns and the two condition levels, it first
+  checks the design from the metadata alone (donors per group, donor nesting within condition,
+  batch separation of condition), then runs a naive per-cell test and a donor-pseudobulk test on
+  the same frozen gene universe, each against a donor-permutation null, and reports each arm's
+  permutation floor, the ratio of the real-label result to that floor and the genomic inflation
+  factor, with caveats, as JSON, Markdown and HTML.
+project_home: https://github.com/s4s4s4s/pbcheck
+documentation_home: https://github.com/s4s4s4s/pbcheck/blob/main/docs/USAGE.md
+tutorials_home: https://github.com/s4s4s4s/pbcheck/blob/main/demo/README.md
+inventory: null
+install:
+  pypi: pbcheck
+primary_category: scRNA-seq
+tags:
+  - scRNA-seq
+  - differential expression
+  - quality control
+license: BSD-3-Clause
+language: Python
+contact:
+  - s4s4s4s
+test_command: pip install ".[dev]" && pytest -m "not slow"
+category: ecosystem


### PR DESCRIPTION
### Mandatory

Name of the tool: pbcheck

Short description: Pseudoreplication audit for single-cell differential-expression designs. Given one .h5ad file, the donor and condition columns and the two condition levels, pbcheck checks the design from the metadata (donors per group, donor nesting within condition, batch separation of condition), then runs a naive per-cell test and a donor-pseudobulk test on the same frozen gene universe, each against a donor-permutation null, and reports each arm's permutation floor, the ratio of the real-label result to that floor and the genomic inflation factor, with caveats, as JSON, Markdown and HTML.

How does the package use scverse data structures (please describe in a few sentences): pbcheck reads its input with anndata (read_h5ad) and works on the AnnData object throughout. The donor, condition and batch columns are taken from obs, the gene identifiers from var, and the raw counts from X or from a layer named on the command line (it refuses a matrix that does not hold counts rather than rounding it). The design audit, the per-cell test and the donor-pseudobulk test all run on that AnnData object.

- [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license (BSD-3-Clause)
- [x] The package provides versioned releases (v0.1.0, 2026-09-07, tagged on GitHub and archived on Zenodo)
- [x] The package can be installed from a standard registry (PyPI: `pip install pbcheck`)
- [x] Automated tests cover essential functions of the package and a reasonable range of inputs and conditions (pytest, 725 tests, including property-based tests with hypothesis)
- [x] Continuous integration (CI) automatically executes these tests on each push or pull request (GitHub Actions on Linux, macOS and Windows, Python 3.12 and 3.13)
- [x] The package provides API documentation via a website or README (the public interface is the CLI; docs/USAGE.md is its full reference, every option and every number in the report)
- [x] The package uses scverse datastructures where appropriate (AnnData, read from .h5ad)
- [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website
- [x] I agree to abide by the [scverse code of conduct](https://scverse.org/about/code_of_conduct/) on all scverse communication channels

### Recommended

- [ ] Please announce this package on scverse communication channels (zulip, discourse, twitter): a Showcase post on discourse is going up today
- [ ] Please tag the author(s) these announcements. Handles (e.g. `@scverse_team`) to include are:
    - Zulip:
    - Discourse:
    - Mastodon:
    - Bluesky:
    - Twitter:
- [x] The package provides tutorials (or "vignettes") that help getting users started quickly (two committed demonstrations under demo/, with the commands and the reports they produce)
- [ ] The package uses the [scverse cookiecutter template](https://github.com/scverse/cookiecutter-scverse).
- [ ] I would like to be invited to the scverse Github organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
