### PR TITLE
Add TorchDR to ecosystem packages

### DIFF
--- a/packages/TorchDR/meta.yaml
+++ b/packages/TorchDR/meta.yaml
@@ -1,0 +1,23 @@
+name: TorchDR
+description: |
+  TorchDR is a high-performance dimensionality reduction library built on PyTorch. It
+  provides GPU and multi-GPU implementations of methods including UMAP, t-SNE, PACMAP,
+  PHATE, and PCA through a scikit-learn-compatible API.
+project_home: https://github.com/TorchDR/TorchDR
+documentation_home: https://torchdr.github.io/dev/
+tutorials_home: https://torchdr.github.io/dev/auto_examples/index.html
+install:
+  pypi: torchdr
+primary_category: Infrastructure
+tags:
+  - scRNA-seq
+  - dimensionality reduction
+  - visualization
+  - optimal transport
+  - GPU acceleration
+license: BSD-3-Clause
+language: Python
+contact:
+  - huguesva
+test_command: pip install ".[test]" && pytest
+category: ecosystem


### PR DESCRIPTION
Name of the tool: TorchDR

Short description: TorchDR is a high-performance dimensionality reduction library built on PyTorch, with GPU and multi-GPU implementations exposed through a scikit-learn-compatible API.

How does the package use scverse data structures: TorchDR follows an array-based API and works with matrices and embeddings stored in AnnData, including `adata.X` and `adata.obsm`. Its [CellxGene Census example](https://github.com/TorchDR/TorchDR/blob/main/examples/single_cell/census.py) receives an AnnData object, reads standard `obs` and `obsm` fields, and applies LargeVis to a stored scGPT embedding; generated embeddings can be stored back in `obsm`.

### Mandatory

- [x] The code is publicly available under an [OSI-approved](https://opensource.org/licenses/alphabetical) license
- [x] The package provides versioned releases
- [x] The package can be installed from a standard registry (PyPI: `torchdr`)
- [x] Automated tests cover essential functions of the package and a reasonable range of inputs and conditions
- [x] Continuous integration (CI) automatically executes these tests on each push or pull request
- [x] The package provides API documentation via a website
- [x] The package uses scverse datastructures where appropriate (AnnData)
- [x] I am an author or maintainer of the tool and agree on listing the package on the scverse website
- [x] I agree to abide by the [scverse code of conduct](https://scverse.org/about/code_of_conduct/) on all scverse communication channels

### Recommended

- [ ] Please announce this package on scverse communication channels (zulip, discourse, twitter)
- [x] The package provides tutorials that help users get started quickly
- [ ] The package uses the scverse cookiecutter template
- [ ] I would like to be invited to the scverse GitHub organization

### Validation

- [x] Registry schema, package metadata, project URLs, documentation inventory, and PyPI release validated with the repository validator
- [x] All applicable pre-commit hooks pass